### PR TITLE
Create platform-H SKU pack w/ baseboard and backplane info

### DIFF
--- a/platform-H/config.json
+++ b/platform-H/config.json
@@ -1,0 +1,17 @@
+{
+    "name": "Platform-H",
+    "rules":[
+        {"path": "ipmi-fru.Basbrd Mgmt Ctlr.Board Mfg",
+        "contains": "Intel"},
+        {"path": "ipmi-fru.Basbrd Mgmt Ctlr.Product Name",
+        "equals": "S2600WTT"},
+        {"path": "ipmi-fru.HS Backplane 1 (ID 5).Board Part Number",
+        "regex": "(G97164|G97156)-(\\d{3})"}
+    ],
+    "taskRoot": "tasks",
+    "workflowRoot": "workflows",
+    "httpProfileRoot": "profiles",
+    "httpTemplatesRoot": "templates",
+    "httpStaticRoot": "static"
+}
+


### PR DESCRIPTION
This PR is to create initial Platform-H sku pack. 
Since Platform-H has overlap with Platform-P on SKU rules, I added both 12 drives and 24 drives backplanes/middle-planes info into SKU rules. 
