### PR TITLE
Change iDRAC8 field to Builtin FRU Device (ID 0) field

### DIFF
--- a/dell-c6320/config.json
+++ b/dell-c6320/config.json
@@ -2,11 +2,11 @@
     "name": "Dell C6320",
     "rules": [
         {
-            "path": "ipmi-fru.iDRAC8.Board Mfg",
+            "path": "ipmi-fru.Builtin FRU Device (ID 0).Board Mfg",
             "contains": "DELL"
         },
         {
-            "path": "ipmi-fru.iDRAC8.Board Part Number",
+            "path": "ipmi-fru.Builtin FRU Device (ID 0).Board Part Number",
             "contains": "04FNTC"
         }
     ],

--- a/dell-r630/config.json
+++ b/dell-r630/config.json
@@ -2,11 +2,11 @@
     "name": "Dell R630",
     "rules": [
         {
-            "path": "ipmi-fru.iDRAC8.Board Mfg",
+            "path": "ipmi-fru.Builtin FRU Device (ID 0).Board Mfg",
             "contains": "DELL"
         },
         {
-            "path": "ipmi-fru.iDRAC8.Board Part Number",
+            "path": "ipmi-fru.Builtin FRU Device (ID 0).Board Part Number",
             "contains": "0CNCJW"
         }
     ],


### PR DESCRIPTION
For Dell servers, it is reported that in some version ipmitool, "iDRAC8" field for ipmi-fru souce won't exist. We need change "iDRAC8" field to "Builtin FRU Device (ID 0)" to avoid this kind of issues. For details please refer to: https://hwjiraprd01.corp.emc.com/browse/ODR-607
