### PR TITLE
Add SKU example for cisco nexus switch

### DIFF
--- a/cisco-nexus-3172T/config.json
+++ b/cisco-nexus-3172T/config.json
@@ -1,0 +1,23 @@
+{
+    "name": "Cisco Nexus 3000 Switch - 54 port",
+    "rules": [
+        {
+            "path": "version.chassis_id",
+            "regex": "Nexus 3172T Chassis"
+        },
+        {
+            "path": "version.module_id",
+            "equals": "48x10GT + 6x40G Supervisor"
+        }
+    ],
+    "discoveryGraphName": "Graph.Switch.CiscoNexus3000.Deploy",
+    "discoveryGraphOptions": {
+        "deploy-startup-config": {
+            "startupConfig": "example-cisco-startup-config"
+        },
+        "deploy-boot-images": {
+            "kickstartImage": "n3000-uk9-kickstart.6.0.2.U5.2.bin",
+            "bootImage": "n3000-uk9.6.0.2.U5.2.bin"
+        }
+    }
+}

--- a/cisco-nexus-3172T/templates/example-cisco-startup-config
+++ b/cisco-nexus-3172T/templates/example-cisco-startup-config
@@ -1,0 +1,8 @@
+hostname rackhd-example-cisco-1
+
+# password = a
+username rackhd password 5 $1$.CW.hyB4$OmPM3Fh1J3arWQPCJcbhe0  role network-admin
+snmp-server community rackhd group network-admin
+
+feature telnet
+feature bash-shell

--- a/cisco-nexus-3172T/workflows/deploy-startup-config-boot-images-graph.json
+++ b/cisco-nexus-3172T/workflows/deploy-startup-config-boot-images-graph.json
@@ -1,0 +1,77 @@
+{
+    "friendlyName": "Deploy Cisco Nexus 3000 switch",
+    "injectableName": "Graph.Switch.CiscoNexus3000.Deploy",
+    "options": {
+        "deploy-startup-config": {
+            "startupConfig": null
+        },
+        "deploy-boot-images": {
+            "kickstartImage": null,
+            "bootImage": null
+        }
+    },
+    "tasks": [
+        {
+            "label": "deploy-startup-config",
+            "taskDefinition": {
+                "friendlyName": "Deploy switch startup config",
+                "injectableName": "Task.Inline.Switch.Deploy.StartupConfig",
+                "implementsTask": "Task.Base.Linux.Commands",
+                "options": {
+                    "startupConfig": null,
+                    "startupConfigUri": "{{ api.base }}/templates/{{ options.startupConfig }}",
+                    "commands": [
+                        {
+                            "downloadUrl": "/api/1.1/templates/cisco-deploy-startup-config.py"
+                        }
+                    ]
+                },
+                "properties": {}
+            }
+        },
+        {
+            "label": "deploy-boot-images",
+            "taskDefinition": {
+                "friendlyName": "Deploy switch boot images",
+                "injectableName": "Task.Inline.Switch.Deploy.BootImages",
+                "implementsTask": "Task.Base.Linux.Commands",
+                "options": {
+                    "kickstartImage": null,
+                    "bootImage": null,
+                    "staticDir": "cisco",
+                    "kickstartUri": "{{ api.server }}/{{ options.staticDir }}/{{ options.kickstartImage }}",
+                    "bootImageUri": "{{ api.server }}/{{ options.staticDir }}/{{ options.bootImage }}",
+                    "commands": [
+                        {
+                            "downloadUrl": "/api/1.1/templates/cisco-deploy-boot-images.py"
+                        }
+                    ]
+                },
+                "properties": {}
+            },
+            "waitOn": {
+                "deploy-startup-config": "succeeded"
+            }
+        },
+        {
+            "label": "catalog-switch-config",
+            "taskDefinition": {
+                "friendlyName": "Catalog Cisco Switch Config",
+                "injectableName": "Task.Inline.Catalog.Switch.Cisco.Config",
+                "implementsTask": "Task.Base.Linux.Commands",
+                "options": {
+                    "commands": [
+                        {
+                            "downloadUrl": "/api/1.1/templates/cisco-catalog-config.py",
+                            "catalog": { "format": "json", "source": "config" }
+                        }
+                    ]
+                },
+                "properties": {}
+            },
+            "waitOn": {
+                "deploy-boot-images": "succeeded"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Moving example assets for cisco discovery/deployment out of on-taskgraph/on-http and into here.

@RackHD/corecommitters @zyoung51 @heckj 
