### PR TITLE
Unify cisco config and boot image deployment into one script/task

### DIFF
--- a/cisco-nexus-3172T/config.json
+++ b/cisco-nexus-3172T/config.json
@@ -12,10 +12,8 @@
     ],
     "discoveryGraphName": "Graph.Switch.CiscoNexus3000.Deploy",
     "discoveryGraphOptions": {
-        "deploy-startup-config": {
-            "startupConfig": "example-cisco-startup-config"
-        },
-        "deploy-boot-images": {
+        "deploy-config-and-images": {
+            "startupConfig": "example-cisco-startup-config",
             "kickstartImage": "n3000-uk9-kickstart.6.0.2.U5.2.bin",
             "bootImage": "n3000-uk9.6.0.2.U5.2.bin"
         }

--- a/cisco-nexus-3172T/workflows/deploy-startup-config-boot-images-graph.json
+++ b/cisco-nexus-3172T/workflows/deploy-startup-config-boot-images-graph.json
@@ -2,40 +2,22 @@
     "friendlyName": "Deploy Cisco Nexus 3000 switch",
     "injectableName": "Graph.Switch.CiscoNexus3000.Deploy",
     "options": {
-        "deploy-startup-config": {
-            "startupConfig": null
-        },
-        "deploy-boot-images": {
+        "deploy-config-and-images": {
+            "startupConfig": null,
             "kickstartImage": null,
             "bootImage": null
         }
     },
     "tasks": [
         {
-            "label": "deploy-startup-config",
+            "label": "deploy-config-and-images",
             "taskDefinition": {
-                "friendlyName": "Deploy switch startup config",
-                "injectableName": "Task.Inline.Switch.Deploy.StartupConfig",
+                "friendlyName": "Deploy switch config and images",
+                "injectableName": "Task.Inline.Switch.Deploy.Cisco",
                 "implementsTask": "Task.Base.Linux.Commands",
                 "options": {
                     "startupConfig": null,
                     "startupConfigUri": "{{ api.base }}/templates/{{ options.startupConfig }}",
-                    "commands": [
-                        {
-                            "downloadUrl": "/api/1.1/templates/cisco-deploy-startup-config.py"
-                        }
-                    ]
-                },
-                "properties": {}
-            }
-        },
-        {
-            "label": "deploy-boot-images",
-            "taskDefinition": {
-                "friendlyName": "Deploy switch boot images",
-                "injectableName": "Task.Inline.Switch.Deploy.BootImages",
-                "implementsTask": "Task.Base.Linux.Commands",
-                "options": {
                     "kickstartImage": null,
                     "bootImage": null,
                     "staticDir": "cisco",
@@ -43,14 +25,11 @@
                     "bootImageUri": "{{ api.server }}/{{ options.staticDir }}/{{ options.bootImage }}",
                     "commands": [
                         {
-                            "downloadUrl": "/api/1.1/templates/cisco-deploy-boot-images.py"
+                            "downloadUrl": "/api/1.1/templates/cisco-deploy-config-and-images.py"
                         }
                     ]
                 },
                 "properties": {}
-            },
-            "waitOn": {
-                "deploy-startup-config": "succeeded"
             }
         },
         {
@@ -70,7 +49,7 @@
                 "properties": {}
             },
             "waitOn": {
-                "deploy-boot-images": "succeeded"
+                "deploy-config-and-images": "succeeded"
             }
         }
     ]


### PR DESCRIPTION
There were some difficulties merging a scheduled-config file if it was updated multiple times independently, so drive all updates from the same script.

@RackHD/corecommitters @zyoung51 @heckj @pscharla @johren 
