### PR TITLE
add a skupack rule for the cisco 3132

### DIFF
--- a/cisco-nexus-C3132/config.json
+++ b/cisco-nexus-C3132/config.json
@@ -1,9 +1,9 @@
 {
-    "name": "Cisco Nexus C3164PQ",
+    "name": "Cisco Nexus 3132",
     "rules": [
         {
             "path": "version.chassis_id",
-            "equals": "Nexus3000 C3164PQ Chassis"
+            "equals": "Nexus 3132 Chassis"
         }
     ]
 }


### PR DESCRIPTION
For convince I dumped the catalog here:

onrack@ora:/var/renasar/on-tftp/lib$ curl localhost:8080/api/common/nodes/"5764388250f447f127968"/catalogs | python -mjson.tool
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1633  100  1633    0     0   106k      0 --:--:-- --:--:-- --:--:--  113k
[
    {
        "createdAt": "2016-06-17T17:57:13.822Z",
        "data": {
            "bios_cmpl_time": "10/15/2013",
            "bios_ver_str": "2.7.0",
            "bootflash_size": "1966080",
            "chassis_id": "Nexus 3132 Chassis",
            "cpu_name": "Intel(R) Core(TM) i3- CPU @ 2.00GHz",
            "header_str": "Cisco Nexus Operating System (NX-OS) Software\nTAC supp: http://www.cisco.com/tac\nDocuments: http://www.cisco.com/en/US/products/ps9372/_products_support_series_home.html\nCopyright (c) 2002-2015, Cisco Systems, Inc. Arights reserved.\nThe copyrights to certain works contained herein are owned by\nor third parties and are used and distributed under license.\nSome parts of this soare are covered under the GNU Public\nLicense. A copy of the license is available nhttp://www.gnu.org/licenses/gpl.html.",
            "host_name": "switch",
            "isan_cmpl_time": "3/17/2015 2:00:00",
            "isan_file_name": "bootflash:///n3000-uk9.6.0.2.U5.2.bin",
            "isan_tmstmp": "03/17/2015 12:29:49",
            "kern_uptm_days": "0",
            "kern_uptm_hrs": "2",
            "kern_uptm_mins": "55",
            "kern_uptm_secs": "26",
            "kick_cmpl_time": "3/17/2015 2:00:00",
            "kick_file_name": "bootflash:///n3000-uk9-kickstart.6.0.2.U5.2.bin",
            "kick_tmstmp": "03/17/2015 10:50:07",
            "kickstart_ver_str": "6.0(2)U5(2)",
            "loader_ver_str": "N/A",
            "mem_type": "kB",
            "memory": "3795076",
            "module_id": "32x40G Supervisor",
            "power_seq_ver_str": "Module 1: version v2.1",
            "proc_board_id": "FOC200529L3",
            "rr_ctime": "Fri Jun 17 15:00:01 2016",
            "rr_reason": "Reset Requested by CLI command reload",
            "rr_service": null,
            "rr_sys_ver": "6.0(2)U5(2)",
            "rr_usecs": "563012",
            "sys_ver_str": "6.0(2)U5(2)"
        },
        "id": "576439f980fafc4608a5f0e0",
        "node": "5764388a41250f447f127968",
        "source": "version",
        "updatedAt": "2016-06-17T17:57:13.822Z"
    }
]
