### PR TITLE
remove placeholder items in skupack config.json

### DIFF
--- a/dell-c6320/config.json
+++ b/dell-c6320/config.json
@@ -10,11 +10,7 @@
             "contains": "04FNTC"
         }
     ],
-    "taskRoot": "tasks",
     "workflowRoot": "workflows",
-    "httpProfileRoot": "profiles",
-    "httpTemplatesRoot": "templates",
-    "httpStaticRoot": "static",
     "discoveryGraphName": "Graph.Dell.Discovery",
     "discoveryGraphOptions": {}
 }

--- a/dell-r630/config.json
+++ b/dell-r630/config.json
@@ -10,11 +10,7 @@
             "contains": "0CNCJW"
         }
     ],
-    "taskRoot": "tasks",
     "workflowRoot": "workflows",
-    "httpProfileRoot": "profiles",
-    "httpTemplatesRoot": "templates",
-    "httpStaticRoot": "static",
     "discoveryGraphName": "Graph.Dell.Discovery",
     "discoveryGraphOptions": {}
 }


### PR DESCRIPTION
If  those placeholder items are not removed, the skupack insertion will fail due to this line: https://github.com/RackHD/on-http/blob/master/lib/services/sku-pack-service.js#L474

@RackHD/corecommitters @zyoung51 @pengz1 
