### PR TITLE
Fix ODR-788 Cannot correctly discover DELL R730 and R730XD

### DIFF
--- a/dell-r730xd/config.json
+++ b/dell-r730xd/config.json
@@ -1,5 +1,5 @@
 {
-    "name": "Dell R730",
+    "name": "Dell R730XD",
     "rules": [
         {
             "path": "ipmi-fru.Builtin FRU Device (ID 0).Board Mfg",
@@ -7,7 +7,7 @@
         },
         {
             "path": "ipmi-fru.Builtin FRU Device (ID 0).Board Part Number",
-            "contains": "072T6D"
+            "contains": "04N3DF"
         }
     ],
     "workflowRoot": "workflows",

--- a/dell-r730xd/workflows/dell-discovery-graph.json
+++ b/dell-r730xd/workflows/dell-discovery-graph.json
@@ -1,0 +1,29 @@
+{
+    "friendlyName": "Dell Discovery",
+    "injectableName": "Graph.Dell.Discovery",
+    "options": {
+        "bootstrap-ubuntu": {
+            "overlayfs": "common/dell.raid.overlay.cpio.gz"
+        }
+    },
+    "tasks": [
+        {
+            "label": "bootstrap-ubuntu",
+            "taskName": "Task.Linux.Bootstrap.Ubuntu"
+        },
+        {
+            "label": "catalog-perccli",
+            "taskName": "Task.Catalog.perccli",
+            "waitOn": {
+                "bootstrap-ubuntu": "succeeded"
+            }
+        },
+        {
+            "label": "shell-reboot",
+            "taskName": "Task.ProcShellReboot",
+            "waitOn": {
+                "catalog-perccli": "finished"
+            }
+        }
+    ]
+}

--- a/dell-r730xd/workflows/dell-perccli-create-megaraid-graph.json
+++ b/dell-r730xd/workflows/dell-perccli-create-megaraid-graph.json
@@ -1,0 +1,54 @@
+{
+    "friendlyName": "Create RAID via perccli",
+    "injectableName": "Graph.Raid.Create.Perccli",
+    "options": {
+        "bootstrap-ubuntu": {
+            "overlayfs": "common/dell.raid.overlay.cpio.gz"
+        },
+        "create-raid": {
+            "path": "/opt/MegaRAID/perccli/perccli64"
+        }
+    },
+    "tasks": [
+        {
+            "ignoreFailure": true,
+            "label": "set-boot-pxe",
+            "taskName": "Task.Obm.Node.PxeBoot"
+        },
+        {
+            "label": "reboot",
+            "taskName": "Task.Obm.Node.Reboot",
+            "waitOn": {
+                "set-boot-pxe": "finished"
+            }
+        },
+        {
+            "label": "bootstrap-ubuntu",
+            "taskName": "Task.Linux.Bootstrap.Ubuntu",
+            "waitOn": {
+                "reboot": "succeeded"
+            }
+        },
+        {
+            "label": "create-raid",
+            "taskName": "Task.Raid.Create.MegaRAID",
+            "waitOn": {
+                "bootstrap-ubuntu": "succeeded"
+            }
+        },
+        {
+            "label": "refresh-catalog-megaraid",
+            "taskName": "Task.Catalog.perccli",
+            "waitOn": {
+                "create-raid": "succeeded"
+            }
+        },
+        {
+            "label": "final-reboot",
+            "taskName": "Task.Obm.Node.Reboot",
+            "waitOn": {
+                "refresh-catalog-megaraid": "finished"
+            }
+        }
+    ]
+}

--- a/dell-r730xd/workflows/dell-perccli-delete-megaraid-graph.json
+++ b/dell-r730xd/workflows/dell-perccli-delete-megaraid-graph.json
@@ -1,0 +1,54 @@
+{
+    "friendlyName": "Delete RAID via Perccli",
+    "injectableName": "Graph.Raid.Delete.Perccli",
+    "options": {
+        "bootstrap-ubuntu": {
+            "overlayfs": "common/dell.raid.overlay.cpio.gz"
+        },
+        "delete-raid": {
+            "path": "/opt/MegaRAID/perccli/perccli64"
+        }
+    },
+    "tasks": [
+        {
+            "ignoreFailure": true,
+            "label": "set-boot-pxe",
+            "taskName": "Task.Obm.Node.PxeBoot"
+        },
+        {
+            "label": "reboot",
+            "taskName": "Task.Obm.Node.Reboot",
+            "waitOn": {
+                "set-boot-pxe": "finished"
+            }
+        },
+        {
+            "label": "bootstrap-ubuntu",
+            "taskName": "Task.Linux.Bootstrap.Ubuntu",
+            "waitOn": {
+                "reboot": "succeeded"
+            }
+        },
+        {
+            "label": "delete-raid",
+            "taskName": "Task.Raid.Delete.MegaRAID",
+            "waitOn": {
+                "bootstrap-ubuntu": "succeeded"
+            }
+        },
+        {
+            "label": "refresh-catalog-megaraid",
+            "taskName": "Task.Catalog.perccli",
+            "waitOn": {
+                "delete-raid": "succeeded"
+            }
+        },
+        {
+            "label": "final-reboot",
+            "taskName": "Task.Obm.Node.Reboot",
+            "waitOn": {
+                "refresh-catalog-megaraid": "finished"
+            }
+        }
+    ]
+}

--- a/dell-r730xd/workflows/dell-perccli-megaraid-catalog.json
+++ b/dell-r730xd/workflows/dell-perccli-megaraid-catalog.json
@@ -1,0 +1,45 @@
+{
+    "friendlyName": "Dell perccli Catalog",
+    "injectableName": "Graph.Dell.perccli.Catalog",
+    "options": {
+        "bootstrap-ubuntu": {
+            "overlayfs": "common/dell.raid.overlay.cpio.gz"
+        }
+    },
+    "tasks": [
+        {
+            "ignoreFailure": true,
+            "label": "set-boot-pxe",
+            "taskName": "Task.Obm.Node.PxeBoot"
+        },
+        {
+            "label": "reboot-start",
+            "taskName": "Task.Obm.Node.Reboot",
+            "waitOn": {
+                "set-boot-pxe": "finished"
+            }
+        },
+        {
+            "label": "bootstrap-ubuntu",
+            "taskName": "Task.Linux.Bootstrap.Ubuntu",
+            "waitOn": {
+                "reboot-start": "succeeded"
+            }
+        },
+        {
+            "ignoreFailure": true,
+            "label": "catalog-perccli",
+            "taskName": "Task.Catalog.perccli",
+            "waitOn": {
+                "bootstrap-ubuntu": "succeeded"
+            }
+        },
+        {
+            "label": "shell-reboot",
+            "taskName": "Task.ProcShellReboot",
+            "waitOn": {
+                "catalog-perccli": "finished"
+            }
+        }
+    ]
+}

--- a/dell-r730xd/workflows/dell-racadm-get-bios-graph.json
+++ b/dell-r730xd/workflows/dell-racadm-get-bios-graph.json
@@ -1,0 +1,17 @@
+{
+    "friendlyName": "Dell Racadm Get BIOS Graph",
+    "injectableName": "Graph.Dell.Racadm.GetBIOS",
+    "options": {
+        "defaults": {
+            "serverFilePath": null,
+            "serverPassword": null,
+            "serverUsername": null
+        }
+    },
+    "tasks": [
+        {
+            "label": "dell-racadm-get-bios",
+            "taskName": "Task.Dell.Racadm.GetBIOS"
+        }
+    ]
+}

--- a/dell-r730xd/workflows/dell-racadm-get-config-catalog-graph.json
+++ b/dell-r730xd/workflows/dell-racadm-get-config-catalog-graph.json
@@ -1,0 +1,11 @@
+{
+    "friendlyName": "Dell Racadm Get Config Catalog Graph",
+    "injectableName": "Graph.Dell.Racadm.GetConfigCatalog",
+    "option": {},
+    "tasks": [
+        {
+            "label": "dell-racadm-get-config-catalog",
+            "taskName": "Task.Dell.Racadm.GetConfigCatalog"
+        }
+    ]
+}

--- a/dell-r730xd/workflows/dell-racadm-set-bios-graph.json
+++ b/dell-r730xd/workflows/dell-racadm-set-bios-graph.json
@@ -1,0 +1,17 @@
+{
+    "friendlyName": "Dell Racadm Set BIOS Graph",
+    "injectableName": "Graph.Dell.Racadm.SetBIOS",
+    "options": {
+        "defaults": {
+            "serverFilePath": null,
+            "serverPassword": null,
+            "serverUsername": null
+        }
+    },
+    "tasks": [
+        {
+            "label": "dell-racadm-set-bios",
+            "taskName": "Task.Dell.Racadm.SetBIOS"
+        }
+    ]
+}

--- a/dell-r730xd/workflows/dell-racadm-update-firmware-graph.json
+++ b/dell-r730xd/workflows/dell-racadm-update-firmware-graph.json
@@ -1,0 +1,17 @@
+{
+    "friendlyName": "Dell Racadm Update Firmware Graph",
+    "injectableName": "Graph.Dell.Racadm.Update.Firmware",
+    "options": {
+        "defaults": {
+            "serverFilePath": null,
+            "serverPassword": null,
+            "serverUsername": null
+        }
+    },
+    "tasks": [
+        {
+            "label": "dell-racadm-update-firmware",
+            "taskName": "Task.Dell.Racadm.Update.Firmware"
+        }
+    ]
+}


### PR DESCRIPTION
Cannot correctly discover DELL R730 server by using the redfish API /redfish/v1/Chassis/
{identifier}, the result shows the name field of R730 node as "unmanaged".
And it will wrongly discover DELL R730XD as R730.
The BoardPartNumber of R730XD is 04N3DFA07, but that of R730 is 072T6DA01.

Solution:
Add skupack for R730XD, and change the rule for R730

@RackHD/corecommitters @panpan0000 
