### PR TITLE
fix: no option task when update quanta firmware

### DIFF
--- a/quanta-d51-2u/tasks/flash-quanta-bmc.json
+++ b/quanta-d51-2u/tasks/flash-quanta-bmc.json
@@ -7,7 +7,7 @@
       "downloadDir": "/opt/downloads",
       "commands": [
         "sudo /opt/socflash/socflash_x64 -b /opt/uploads/bmc-backup.bin",
-        "sudo curl -T /opt/uploads/bmc-backup.bin {{ api.files }}/{{ task.nodeId }}-bmc-backup.bin",
+        "sudo curl -T /opt/uploads/bmc-backup.bin {{ api.files }}/{{ nodeId }}-bmc-backup.bin",
         "sudo /opt/socflash/socflash_x64 -s option=x flashtype=2 if={{ options.downloadDir }}/{{ options.file }}"
       ]
     },

--- a/quanta-d51-2u/templates/flash_bios.sh
+++ b/quanta-d51-2u/templates/flash_bios.sh
@@ -36,7 +36,7 @@ pushd ${DOWNLOAD_DIR}
 #Snapshot the current image
 VERSION=`${CMD} /S | grep 'ROM ID' | awk -F= '{print $2}' | tr -d ' '`
 ${CMD} backup.bin /O
-curl -T ./${BACKUP_FILE} <%= api.files %>/<%= task.nodeId %>-${VERSION}
+curl -T ./${BACKUP_FILE} <%= api.files %>/<%= nodeId %>-${VERSION}
 
 # Flash new image
 ${CMD} <%= sku.biosFirmware.args %>

--- a/quanta-d51-2u/templates/flash_nvram.sh
+++ b/quanta-d51-2u/templates/flash_nvram.sh
@@ -33,8 +33,8 @@ FLASH_FILE=${DOWNLOAD_DIR}/${filename##*/}
 
 pushd ${DOWNLOAD_DIR}
 ${CMD} /o /s biosNvramSettingsBackup
-curl -T ./biosNvramSettingsBackup <%= api.files %>/<%= task.nodeId %>-biosNvramSettingsBackup
+curl -T ./biosNvramSettingsBackup <%= api.files %>/<%= nodeId %>-biosNvramSettingsBackup
 ${CMD} <%= sku.nvramFirmware.args %>
 ${CMD} /o /s biosNvramSettingsCurrent
-curl -T ./biosNvramSettingsCurrent <%= api.files %>/<%= task.nodeId %>-biosNvramSettingsCurrent
+curl -T ./biosNvramSettingsCurrent <%= api.files %>/<%= nodeId %>-biosNvramSettingsCurrent
 

--- a/quanta-t41/tasks/flash-quanta-bmc.json
+++ b/quanta-t41/tasks/flash-quanta-bmc.json
@@ -7,7 +7,7 @@
       "downloadDir": "/opt/downloads",
       "commands": [
         "sudo /opt/socflash/socflash_x64 -b /opt/uploads/bmc-backup.bin",
-        "sudo curl -T /opt/uploads/bmc-backup.bin {{ api.files }}/{{ task.nodeId }}-bmc-backup.bin",
+        "sudo curl -T /opt/uploads/bmc-backup.bin {{ api.files }}/{{ nodeId }}-bmc-backup.bin",
         "sudo /opt/socflash/socflash_x64 -s option=x flashtype=2 if={{ options.downloadDir }}/{{ options.file }}"
       ]
     },

--- a/quanta-t41/templates/flash_bios.sh
+++ b/quanta-t41/templates/flash_bios.sh
@@ -36,7 +36,7 @@ pushd ${DOWNLOAD_DIR}
 #Snapshot the current image
 VERSION=`${CMD} /S | grep 'ROM ID' | awk -F= '{print $2}' | tr -d ' '`
 ${CMD} backup.bin /O
-curl -T ./${BACKUP_FILE} <%= api.files %>/<%= task.nodeId %>-${VERSION}
+curl -T ./${BACKUP_FILE} <%= api.files %>/<%= nodeId %>-${VERSION}
 
 # Flash new image
 ${CMD} <%= sku.biosFirmware.args %>

--- a/quanta-t41/templates/flash_nvram.sh
+++ b/quanta-t41/templates/flash_nvram.sh
@@ -33,8 +33,8 @@ FLASH_FILE=${DOWNLOAD_DIR}/${filename##*/}
 
 pushd ${DOWNLOAD_DIR}
 ${CMD} /o /s biosNvramSettingsBackup
-curl -T ./biosNvramSettingsBackup <%= api.files %>/<%= task.nodeId %>-biosNvramSettingsBackup
+curl -T ./biosNvramSettingsBackup <%= api.files %>/<%= nodeId %>-biosNvramSettingsBackup
 ${CMD} <%= sku.nvramFirmware.args %>
 ${CMD} /o /s biosNvramSettingsCurrent
-curl -T ./biosNvramSettingsCurrent <%= api.files %>/<%= task.nodeId %>-biosNvramSettingsCurrent
+curl -T ./biosNvramSettingsCurrent <%= api.files %>/<%= nodeId %>-biosNvramSettingsCurrent
 


### PR DESCRIPTION
update firmware failed:
_task is not defined
 -> /lib/services/common-api-presenter.js:110
error:
  stack:
    - ReferenceError: ejs:39
    -     37| VERSION=`${CMD} /S | grep 'ROM ID' | awk -F= '{print $2}' | tr -d ' '`
    -     38| ${CMD} backup.bin /O
    -  >> 39| curl -T ./${BACKUP_FILE} <%= api.files %>/<%= task.nodeId %>-${VERSION}
    -     40|
    -     41| # Flash new image
    -     42| ${CMD} <%= sku.biosFirmware.args %>_

task.nodeId is replaced by nodeId.
