### PR TITLE
Add schema for quanta firmware update tasks and remove null options

### DIFF
--- a/dell-c6320/workflows/dell-racadm-get-bios-graph.json
+++ b/dell-c6320/workflows/dell-racadm-get-bios-graph.json
@@ -2,11 +2,7 @@
     "friendlyName": "Dell Racadm Get BIOS Graph",
     "injectableName": "Graph.Dell.Racadm.GetBIOS",
     "options": {
-        "defaults": {
-            "serverFilePath": null,
-            "serverPassword": null,
-            "serverUsername": null
-        }
+        "defaults": {}
     },
     "tasks": [
         {

--- a/dell-c6320/workflows/dell-racadm-set-bios-graph.json
+++ b/dell-c6320/workflows/dell-racadm-set-bios-graph.json
@@ -2,11 +2,7 @@
     "friendlyName": "Dell Racadm Set BIOS Graph",
     "injectableName": "Graph.Dell.Racadm.SetBIOS",
     "options": {
-        "defaults": {
-            "serverFilePath": null,
-            "serverPassword": null,
-            "serverUsername": null
-        }
+        "defaults": {}
     },
     "tasks": [
         {

--- a/dell-c6320/workflows/dell-racadm-update-firmware-graph.json
+++ b/dell-c6320/workflows/dell-racadm-update-firmware-graph.json
@@ -2,11 +2,7 @@
     "friendlyName": "Dell Racadm Update Firmware Graph",
     "injectableName": "Graph.Dell.Racadm.Update.Firmware",
     "options": {
-        "defaults": {
-            "serverFilePath": null,
-            "serverPassword": null,
-            "serverUsername": null
-        }
+        "defaults": {}
     },
     "tasks": [
         {

--- a/dell-r630/workflows/dell-racadm-get-bios-graph.json
+++ b/dell-r630/workflows/dell-racadm-get-bios-graph.json
@@ -2,11 +2,7 @@
     "friendlyName": "Dell Racadm Get BIOS Graph",
     "injectableName": "Graph.Dell.Racadm.GetBIOS",
     "options": {
-        "defaults": {
-            "serverFilePath": null,
-            "serverPassword": null,
-            "serverUsername": null
-        }
+        "defaults": {}
     },
     "tasks": [
         {

--- a/dell-r630/workflows/dell-racadm-set-bios-graph.json
+++ b/dell-r630/workflows/dell-racadm-set-bios-graph.json
@@ -2,11 +2,7 @@
     "friendlyName": "Dell Racadm Set BIOS Graph",
     "injectableName": "Graph.Dell.Racadm.SetBIOS",
     "options": {
-        "defaults": {
-            "serverFilePath": null,
-            "serverPassword": null,
-            "serverUsername": null
-        }
+        "defaults": {}
     },
     "tasks": [
         {

--- a/dell-r630/workflows/dell-racadm-update-firmware-graph.json
+++ b/dell-r630/workflows/dell-racadm-update-firmware-graph.json
@@ -2,11 +2,7 @@
     "friendlyName": "Dell Racadm Update Firmware Graph",
     "injectableName": "Graph.Dell.Racadm.Update.Firmware",
     "options": {
-        "defaults": {
-            "serverFilePath": null,
-            "serverPassword": null,
-            "serverUsername": null
-        }
+        "defaults": {}
     },
     "tasks": [
         {

--- a/dell-r730/workflows/dell-racadm-get-bios-graph.json
+++ b/dell-r730/workflows/dell-racadm-get-bios-graph.json
@@ -2,11 +2,7 @@
     "friendlyName": "Dell Racadm Get BIOS Graph",
     "injectableName": "Graph.Dell.Racadm.GetBIOS",
     "options": {
-        "defaults": {
-            "serverFilePath": null,
-            "serverPassword": null,
-            "serverUsername": null
-        }
+        "defaults": {}
     },
     "tasks": [
         {

--- a/dell-r730/workflows/dell-racadm-set-bios-graph.json
+++ b/dell-r730/workflows/dell-racadm-set-bios-graph.json
@@ -2,11 +2,7 @@
     "friendlyName": "Dell Racadm Set BIOS Graph",
     "injectableName": "Graph.Dell.Racadm.SetBIOS",
     "options": {
-        "defaults": {
-            "serverFilePath": null,
-            "serverPassword": null,
-            "serverUsername": null
-        }
+        "defaults": {}
     },
     "tasks": [
         {

--- a/dell-r730/workflows/dell-racadm-update-firmware-graph.json
+++ b/dell-r730/workflows/dell-racadm-update-firmware-graph.json
@@ -2,11 +2,7 @@
     "friendlyName": "Dell Racadm Update Firmware Graph",
     "injectableName": "Graph.Dell.Racadm.Update.Firmware",
     "options": {
-        "defaults": {
-            "serverFilePath": null,
-            "serverPassword": null,
-            "serverUsername": null
-        }
+        "defaults": {}
     },
     "tasks": [
         {

--- a/dell-r730xd/workflows/dell-racadm-get-bios-graph.json
+++ b/dell-r730xd/workflows/dell-racadm-get-bios-graph.json
@@ -2,11 +2,7 @@
     "friendlyName": "Dell Racadm Get BIOS Graph",
     "injectableName": "Graph.Dell.Racadm.GetBIOS",
     "options": {
-        "defaults": {
-            "serverFilePath": null,
-            "serverPassword": null,
-            "serverUsername": null
-        }
+        "defaults": {}
     },
     "tasks": [
         {

--- a/dell-r730xd/workflows/dell-racadm-set-bios-graph.json
+++ b/dell-r730xd/workflows/dell-racadm-set-bios-graph.json
@@ -2,11 +2,7 @@
     "friendlyName": "Dell Racadm Set BIOS Graph",
     "injectableName": "Graph.Dell.Racadm.SetBIOS",
     "options": {
-        "defaults": {
-            "serverFilePath": null,
-            "serverPassword": null,
-            "serverUsername": null
-        }
+        "defaults": {}
     },
     "tasks": [
         {

--- a/dell-r730xd/workflows/dell-racadm-update-firmware-graph.json
+++ b/dell-r730xd/workflows/dell-racadm-update-firmware-graph.json
@@ -2,11 +2,7 @@
     "friendlyName": "Dell Racadm Update Firmware Graph",
     "injectableName": "Graph.Dell.Racadm.Update.Firmware",
     "options": {
-        "defaults": {
-            "serverFilePath": null,
-            "serverPassword": null,
-            "serverUsername": null
-        }
+        "defaults": {}
     },
     "tasks": [
         {

--- a/quanta-d51-2u/README.md
+++ b/quanta-d51-2u/README.md
@@ -1,8 +1,8 @@
 # Quanta D51 skupack
 
-## BIOS firmware upgarde
+## BIOS firmware upgrade
 - The BIOS firmware files should be acquired from the vendor.  The BIOS image and BIOS upgrade executable are then extracted into the /static/bios location of the skupack and the config.json should be updated with the md5sum of the firmware image.
-- A valid BMC or BIOS firmware image should end with .bin, .BIN, .zip, .img or .ima, and only image path with bios/, bmc/ folder or without folder are supported. Other format of "file" value will be recognized as fault by schema validator.
+- A valid BMC or BIOS firmware image is made up of path and filename like bios/file.img. Image filename should end with .bin, .BIN, .zip, .img or .ima. Image path should be "bios/", "bmc/" or empty value. Other format of image will be recognized as incorrect by schema validator.
 - The following vendor versions have been validated with this skupack
  1. S2B_3A19.DDN02.BIN
  2. S2B_3A21.BIN
@@ -50,7 +50,7 @@ curl -X PUT -T file.img http://localhost:8080/api/current/files/file.img
 ```
 ## BMC firmware upgrade
 - The BMC firmware files should be acquired from the vendor.  The BMC image and BMC upgrade executable are then extracted into the /static/bmc location of the skupack and the config.json should be updated with the md5sum of the firmware image.
-- A valid BMC or BIOS firmware image should end with .bin, .BIN, .zip, .img or .ima, and only image path with bios/, bmc/ folder or without folder are supported. Other format of "file" value will be recognized as fault by schema validator.
+- A valid BMC or BIOS firmware image is made up of path and filename like bios/file.img. Image filename should end with .bin, .BIN, .zip, .img or .ima. Image path should be "bios/", "bmc/" or empty value. Other format of image will be recognized as incorrect by schema validator.
 - The following vendor versions have been validated with this skupack
  1. 3.32
  2. 3.42

--- a/quanta-d51-2u/README.md
+++ b/quanta-d51-2u/README.md
@@ -2,6 +2,7 @@
 
 ## BIOS firmware upgarde
 - The BIOS firmware files should be acquired from the vendor.  The BIOS image and BIOS upgrade executable are then extracted into the /static/bios location of the skupack and the config.json should be updated with the md5sum of the firmware image.
+- A valid BMC or BIOS firmware image should end with .bin, .BIN, .zip, .img or .ima, and only image path with bios/, bmc/ folder or without folder are supported. Other format of "file" value will be recognized as fault by schema validator.
 - The following vendor versions have been validated with this skupack
  1. S2B_3A19.DDN02.BIN
  2. S2B_3A21.BIN
@@ -49,6 +50,7 @@ curl -X PUT -T file.img http://localhost:8080/api/current/files/file.img
 ```
 ## BMC firmware upgrade
 - The BMC firmware files should be acquired from the vendor.  The BMC image and BMC upgrade executable are then extracted into the /static/bmc location of the skupack and the config.json should be updated with the md5sum of the firmware image.
+- A valid BMC or BIOS firmware image should end with .bin, .BIN, .zip, .img or .ima, and only image path with bios/, bmc/ folder or without folder are supported. Other format of "file" value will be recognized as fault by schema validator.
 - The following vendor versions have been validated with this skupack
  1. 3.32
  2. 3.42

--- a/quanta-d51-2u/workflows/flash-quanta-bios-graph.json
+++ b/quanta-d51-2u/workflows/flash-quanta-bios-graph.json
@@ -34,14 +34,14 @@
           "friendlyName": "Upgrade firmware images",
           "injectableName": "Task.Linux.Command.Upgrade.BIOS",
           "implementsTask": "Task.Base.Linux.Commands",
+          "schemaRef": "sku-firmware-update.json", 
           "options": {
             "commands": [
               {
                 "command": "sudo ./flash_bios.sh",
                 "downloadUrl": "/api/1.1/templates/flash_bios.sh"
               }
-            ],
-            "file": null
+            ]
           },
           "properties": {}
         },

--- a/quanta-d51-2u/workflows/flash-quanta-bmc-graph.json
+++ b/quanta-d51-2u/workflows/flash-quanta-bmc-graph.json
@@ -44,14 +44,14 @@
           "friendlyName": "Upgrade firmware images",
           "injectableName": "Task.Linux.Command.Upgrade.Bmc",
           "implementsTask": "Task.Base.Linux.Commands",
+          "schemaRef": "sku-firmware-update.json",
           "options": {
             "commands": [
               {
                 "command": "sudo ./flash_bmc.sh",
                 "downloadUrl": "/api/1.1/templates/flash_bmc.sh"
               }
-            ],
-            "file": null
+            ]
           },
           "properties": {}
         },

--- a/quanta-d51-2u/workflows/write-quanta-bios-nvram-graph.json
+++ b/quanta-d51-2u/workflows/write-quanta-bios-nvram-graph.json
@@ -39,8 +39,7 @@
                 "command": "sudo ./flash_nvram.sh",
                 "downloadUrl": "/api/1.1/templates/flash_nvram.sh"
               }
-            ],
-            "file": null
+            ]
           },
           "properties": {}
         },

--- a/quanta-t41/README.md
+++ b/quanta-t41/README.md
@@ -2,6 +2,7 @@
 
 ## BIOS firmware upgarde
 - The BIOS firmware files should be acquired from the vendor.  The BIOS image and BIOS upgrade executable are then extracted into the /static/bios location of the skupack and the config.json should be updated with the md5sum of the firmware image.
+- A valid BMC or BIOS firmware image should end with .bin, .BIN, .zip, .img or .ima, and only image path with bios/, bmc/ folder or without folder are supported. Other format of "file" value will be recognized as fault by schema validator.
 - The following vendor versions have been validated with this skupack
  1. S2S_3A14
  2. S2S_3A17
@@ -51,6 +52,7 @@ curl -X PUT -T file.img http://localhost:8080/api/current/files/file.img
 
 ## BMC firmware upgrade
 - The BMC firmware files should be acquired from the vendor.  The BMC image and BMC upgrade executable are then extracted into the /static/bmc location of the skupack and the config.json should be updated with the md5sum of the firmware image.
+- A valid BMC or BIOS firmware image should end with .bin, .BIN, .zip, .img or .ima, and only image path with bios/, bmc/ folder or without folder are supported. Other format of "file" value will be recognized as fault by schema validator.
 - The following vendor versions have been validated with this skupack
  1. 3.30
  2. 3.36

--- a/quanta-t41/README.md
+++ b/quanta-t41/README.md
@@ -1,8 +1,8 @@
 # Quanta T41 skupack
 
-## BIOS firmware upgarde
+## BIOS firmware upgrade
 - The BIOS firmware files should be acquired from the vendor.  The BIOS image and BIOS upgrade executable are then extracted into the /static/bios location of the skupack and the config.json should be updated with the md5sum of the firmware image.
-- A valid BMC or BIOS firmware image should end with .bin, .BIN, .zip, .img or .ima, and only image path with bios/, bmc/ folder or without folder are supported. Other format of "file" value will be recognized as fault by schema validator.
+- A valid BMC or BIOS firmware image is made up of path and filename like bios/file.img. Image filename should end with .bin, .BIN, .zip, .img or .ima. Image path should be "bios/", "bmc/" or empty value. Other format of image will be recognized as incorrect by schema validator.
 - The following vendor versions have been validated with this skupack
  1. S2S_3A14
  2. S2S_3A17
@@ -52,7 +52,7 @@ curl -X PUT -T file.img http://localhost:8080/api/current/files/file.img
 
 ## BMC firmware upgrade
 - The BMC firmware files should be acquired from the vendor.  The BMC image and BMC upgrade executable are then extracted into the /static/bmc location of the skupack and the config.json should be updated with the md5sum of the firmware image.
-- A valid BMC or BIOS firmware image should end with .bin, .BIN, .zip, .img or .ima, and only image path with bios/, bmc/ folder or without folder are supported. Other format of "file" value will be recognized as fault by schema validator.
+- A valid BMC or BIOS firmware image is made up of path and filename like bios/file.img. Image filename should end with .bin, .BIN, .zip, .img or .ima. Image path should be "bios/", "bmc/" or empty value. Other format of image will be recognized as incorrect by schema validator.
 - The following vendor versions have been validated with this skupack
  1. 3.30
  2. 3.36

--- a/quanta-t41/workflows/flash-quanta-bios-graph.json
+++ b/quanta-t41/workflows/flash-quanta-bios-graph.json
@@ -34,14 +34,14 @@
           "friendlyName": "Upgrade firmware images",
           "injectableName": "Task.Linux.Command.Upgrade.BIOS",
           "implementsTask": "Task.Base.Linux.Commands",
+          "schemaRef": "sku-firmware-update.json",
           "options": {
             "commands": [
               {
                 "command": "sudo ./flash_bios.sh",
                 "downloadUrl": "/api/1.1/templates/flash_bios.sh"
               }
-            ],
-            "file": null
+            ]
           },
           "properties": {}
         },

--- a/quanta-t41/workflows/flash-quanta-bmc-graph.json
+++ b/quanta-t41/workflows/flash-quanta-bmc-graph.json
@@ -44,14 +44,14 @@
           "friendlyName": "Upgrade firmware images",
           "injectableName": "Task.Linux.Command.Upgrade.Bmc",
           "implementsTask": "Task.Base.Linux.Commands",
+          "schemaRef": "sku-firmware-update.json",  
           "options": {
             "commands": [
               {
                 "command": "sudo ./flash_bmc.sh",
                 "downloadUrl": "/api/1.1/templates/flash_bmc.sh"
               }
-            ],
-            "file": null
+            ]
           },
           "properties": {}
         },

--- a/quanta-t41/workflows/write-quanta-bios-nvram-graph.json
+++ b/quanta-t41/workflows/write-quanta-bios-nvram-graph.json
@@ -39,8 +39,7 @@
                 "command": "sudo ./flash_nvram.sh",
                 "downloadUrl": "/api/1.1/templates/flash_nvram.sh"
               }
-            ],
-            "file": null
+            ]
           },
           "properties": {}
         },


### PR DESCRIPTION
This PR is to add SKU schema verification for quanta firmware update tasks, and remove null options in quanta SKU workflows and dell RACADM related tasks.

Related PR:
https://github.com/RackHD/on-tasks/pull/329
