### PR TITLE
fix odr 828 about hang when flashing Quanta bios

### DIFF
--- a/quanta-d51-2u/README.md
+++ b/quanta-d51-2u/README.md
@@ -43,7 +43,8 @@ POST
 ```
 The file should be uploaded to the RackHD instance with the Files API before
 invoking the workflow and the "file" property should be set to the value of
-the resource name specified in the files URI
+the resource name specified in the files URI. It only works when the default
+API is 2.0 version, meaning no ''"versionBase": "1.1"'' specified in config file
 ```
 curl -X PUT -T file.img http://localhost:8080/api/current/files/file.img
 ```
@@ -90,7 +91,8 @@ POST
 ```
 The file should be uploaded to the RackHD instance with the Files API before
 invoking the workflow and the "file" property should be set to the value of
-the resource name specified in the files URI
+the resource name specified in the files URI. It only works when the default
+API is 2.0 version, meaning no ''"versionBase": "1.1"'' specified in config file
 ```
 curl -X PUT -T file.img http://localhost:8080/api/current/files/file.img
 ```

--- a/quanta-d51-2u/templates/flash_bios.sh
+++ b/quanta-d51-2u/templates/flash_bios.sh
@@ -26,8 +26,8 @@ FLASH_FILE=${DOWNLOAD_DIR}/${filename##*/}
 #
 # Download the user uploaded file if specified to override default
 <% if (typeof file !== 'undefined' && file) { %>
-  fileMd5Uri="<%=api.files%>/md5/<%=file%>/latest"
-  fileUri="<%=api.files%>/<%=file%>/latest"
+  fileMd5Uri="<%=api.files%>/<%=file%>/md5"
+  fileUri="<%=api.files%>/<%=file%>"
   outputPath="${DOWNLOAD_DIR}/<%= file %>"
   curl --retry 3 ${fileUri} -o ${outputPath}
   md5=($(md5sum ${outputPath}))
@@ -46,3 +46,6 @@ curl -T ./${BACKUP_FILE} <%= api.files %>/<%= nodeId %>-${VERSION}
 # Flash new image
 ${CMD} <%= sku.biosFirmware.args %>
 
+# Wait some time for the internal process to finish
+# otherwise catalog ami task after flashing will hang the node in some fw version (like 3A19)
+sleep 30

--- a/quanta-d51-2u/templates/flash_bios.sh
+++ b/quanta-d51-2u/templates/flash_bios.sh
@@ -45,7 +45,3 @@ curl -T ./${BACKUP_FILE} <%= api.files %>/<%= nodeId %>-${VERSION}
 
 # Flash new image
 ${CMD} <%= sku.biosFirmware.args %>
-
-# Wait some time for the internal process to finish
-# otherwise catalog ami task after flashing will hang the node in some fw version (like 3A19)
-sleep 30

--- a/quanta-d51-2u/templates/flash_bmc.sh
+++ b/quanta-d51-2u/templates/flash_bmc.sh
@@ -20,8 +20,8 @@ FLASH_FILE=${DOWNLOAD_DIR}/${filename##*/}
 #
 # Download the user uploaded file if specified to override default
 <% if (typeof file !== 'undefined' && file) { %>
-  fileMd5Uri="<%=api.files%>/md5/<%=file%>/latest"
-  fileUri="<%=api.files%>/<%=file%>/latest"
+  fileMd5Uri="<%=api.files%>/<%=file%>/md5"
+  fileUri="<%=api.files%>/<%=file%>"
   outputPath="${DOWNLOAD_DIR}/<%= file %>"
   curl --retry 3 ${fileUri} -o ${outputPath}
   md5=($(md5sum ${outputPath}))

--- a/quanta-t41/README.md
+++ b/quanta-t41/README.md
@@ -44,7 +44,8 @@ POST
 ```
 The file should be uploaded to the RackHD instance with the Files API before
 invoking the workflow and the "file" property should be set to the value of
-the resource name specified in the files URI
+the resource name specified in the files URI. It only works when the default
+API is 2.0 version, meaning no ''"versionBase": "1.1"'' specified in config file
 ```
 curl -X PUT -T file.img http://localhost:8080/api/current/files/file.img
 ```
@@ -93,7 +94,8 @@ POST
 ```
 The file should be uploaded to the RackHD instance with the Files API before
 invoking the workflow and the "file" property should be set to the value of
-the resource name specified in the files URI
+the resource name specified in the files URI. It only works when the default
+API is 2.0 version, meaning no ''"versionBase": "1.1"'' specified in config file
 ```
 curl -X PUT -T file.img http://localhost:8080/api/current/files/file.img
 ```

--- a/quanta-t41/templates/flash_bios.sh
+++ b/quanta-t41/templates/flash_bios.sh
@@ -45,7 +45,3 @@ curl -T ./${BACKUP_FILE} <%= api.files %>/<%= nodeId %>-${VERSION}
 
 # Flash new image
 ${CMD} <%= sku.biosFirmware.args %>
-
-# Wait some time for the internal process to finish
-# otherwise catalog ami task after flashing will hang the node in some fw verion
-sleep 30

--- a/quanta-t41/templates/flash_bios.sh
+++ b/quanta-t41/templates/flash_bios.sh
@@ -26,8 +26,8 @@ FLASH_FILE=${DOWNLOAD_DIR}/${filename##*/}
 #
 # Download the user uploaded file if specified to override default
 <% if (typeof file !== 'undefined' && file) { %>
-  fileMd5Uri="<%=api.files%>/md5/<%=file%>/latest"
-  fileUri="<%=api.files%>/<%=file%>/latest"
+  fileMd5Uri="<%=api.files%>/<%=file%>/md5"
+  fileUri="<%=api.files%>/<%=file%>"
   outputPath="${DOWNLOAD_DIR}/<%= file %>"
   curl --retry 3 ${fileUri} -o ${outputPath}
   md5=($(md5sum ${outputPath}))
@@ -46,3 +46,6 @@ curl -T ./${BACKUP_FILE} <%= api.files %>/<%= nodeId %>-${VERSION}
 # Flash new image
 ${CMD} <%= sku.biosFirmware.args %>
 
+# Wait some time for the internal process to finish
+# otherwise catalog ami task after flashing will hang the node in some fw verion
+sleep 30

--- a/quanta-t41/templates/flash_bmc.sh
+++ b/quanta-t41/templates/flash_bmc.sh
@@ -20,8 +20,8 @@ FLASH_FILE=${DOWNLOAD_DIR}/${filename##*/}
 #
 # Download the user uploaded file if specified to override default
 <% if (typeof file !== 'undefined' && file) { %>
-  fileMd5Uri="<%=api.files%>/md5/<%=file%>/latest"
-  fileUri="<%=api.files%>/<%=file%>/latest"
+  fileMd5Uri="<%=api.files%>/<%=file%>/md5"
+  fileUri="<%=api.files%>/<%=file%>"
   outputPath="${DOWNLOAD_DIR}/<%= file %>"
   curl --retry 3 ${fileUri} -o ${outputPath}
   md5=($(md5sum ${outputPath}))


### PR DESCRIPTION
This PR includes two changes.

Hang issue occurs in catalog ami tasks after flashing BIOS 3A19. In vendor's document, it is suggested to reboot node right after flashing, but in our workflow, we try to get new bios version after the process.
In this PR, I add sleep time after flashing to wait for its internal process to finish.

If users want to overwrite the fw image, RackHD files/ API will be used, whose format is different in 1.1 and 2.0 version. Currently the default API version has been changed to 2.0, so adjust the API format to this version, and add notes in README file
