### PR TITLE
fix quanta D51 and T41 bmc update failure

### DIFF
--- a/quanta-d51-2u/templates/flash_bmc.sh
+++ b/quanta-d51-2u/templates/flash_bmc.sh
@@ -90,44 +90,46 @@ until [ $counter -le 0 ]; do
            echo "Check didn't pass, ip source wasn't set properly"
            exit 1;
         fi;
-        sleep 2
 
-        #IPMI tool command to set IP address
-        ipmitool lan set 1 ipaddr $ipaddrInfo
-        sleep 8
-        ipaddrCheck=$(ipmitool lan print)
-        ipaddrCheck=(${ipaddrCheck//$'\n'/ })
-        ipaddrCheck=${ipaddrCheck[59]}
-        echo "$ipaddrCheck"
-        if [ $ipaddrCheck != $ipaddrInfo ]; then
-           echo "Check didn't pass, ip address wasn't set properly"
-           exit 1;
-        fi;
-        sleep 2
+        if [ $ipsrcCheck != 'DHCP' ]; then
+            sleep 2
+            #IPMI tool command to set IP address
+            ipmitool lan set 1 ipaddr $ipaddrInfo
+            sleep 8
+            ipaddrCheck=$(ipmitool lan print)
+            ipaddrCheck=(${ipaddrCheck//$'\n'/ })
+            ipaddrCheck=${ipaddrCheck[59]}
+            echo "$ipaddrCheck"
+            if [ $ipaddrCheck != $ipaddrInfo ]; then
+                echo "Check didn't pass, ip address wasn't set properly"
+                exit 1;
+            fi;
+            sleep 2
 
-        #IPMI tool command to set net mask
-        ipmitool lan set 1 netmask $netMaskInfo
-        sleep 8
-        netmaskCheck=$(ipmitool lan print)
-        netmaskCheck=(${netmaskCheck//$'\n'/ })
-        netmaskCheck=${netmaskCheck[63]}
-        echo "$netmaskCheck"
-        if [ ${netmaskCheck} != ${netMaskInfo} ]; then
-           echo "Check didn't pass, netmask wasn't set properly"
-           exit 1;
-        fi;
+            #IPMI tool command to set net mask
+            ipmitool lan set 1 netmask $netMaskInfo
+            sleep 8
+            netmaskCheck=$(ipmitool lan print)
+            netmaskCheck=(${netmaskCheck//$'\n'/ })
+            netmaskCheck=${netmaskCheck[63]}
+            echo "$netmaskCheck"
+            if [ ${netmaskCheck} != ${netMaskInfo} ]; then
+                echo "Check didn't pass, netmask wasn't set properly"
+                exit 1;
+            fi;
 
-        #IPMI tool command to set default gateway address
-        ipmitool lan set 1 defgw ipaddr $defGatewayInfo
-        sleep 8
-        defgwCheck=$(ipmitool lan print)
-        defgwCheck=(${defgwCheck//$'\n'/ })
-        defgwCheck=${defgwCheck[100]}
-        echo "$defgwCheck"
-        if [ ${defgwCheck} != ${defGatewayInfo} ]; then
-           echo "Check didn't pass, default gateway wasn't set properly"
-           exit 1;
-        fi;
+            #IPMI tool command to set default gateway address
+            ipmitool lan set 1 defgw ipaddr $defGatewayInfo
+            sleep 8
+            defgwCheck=$(ipmitool lan print)
+            defgwCheck=(${defgwCheck//$'\n'/ })
+            defgwCheck=${defgwCheck[100]}
+            echo "$defgwCheck"
+            if [ ${defgwCheck} != ${defGatewayInfo} ]; then
+                echo "Check didn't pass, default gateway wasn't set properly"
+                exit 1;
+            fi;
+        fi
         exit 0
     fi
     sleep 1

--- a/quanta-t41/templates/flash_bmc.sh
+++ b/quanta-t41/templates/flash_bmc.sh
@@ -129,8 +129,8 @@ until [ $counter -le 0 ]; do
               echo "Check didn't pass, default gateway wasn't set properly"
               exit 1;
            fi;
-           exit 0
         fi
+        exit 0
     fi
     sleep 1
     let counter-=1


### PR DESCRIPTION
Fix ODR 893.

In Quanta D51, the script restores lan settings after flashing. When the original BMC is DHCP, setting IP to it results an error and the task fails. Add a check before setting IP. If it is DHCP before flashing, skip lan setting process.

In Quanta T41, if BMC is DHCP, the setting loop after flashing won't exit. Move "exit 0" out from the block of lan setting.

@uppalk1 
