### PR TITLE
Add "ignore failure" in FW update workflow

### DIFF
--- a/quanta-d51-2u/workflows/flash-quanta-bios-graph.json
+++ b/quanta-d51-2u/workflows/flash-quanta-bios-graph.json
@@ -61,7 +61,8 @@
         "taskName": "Task.Evaluate.Condition",
         "waitOn": {
           "catalog-quanta-bios-after": "finished"
-        }
+        },
+        "ignoreFailure": true
       },
       {
         "label": "final-reboot",

--- a/quanta-d51-2u/workflows/flash-quanta-bmc-graph.json
+++ b/quanta-d51-2u/workflows/flash-quanta-bmc-graph.json
@@ -71,7 +71,8 @@
         "taskName": "Task.Evaluate.Condition",
         "waitOn": {
           "catalog-quanta-bmc-after": "finished"
-        }
+        },
+        "ignoreFailure": true
       },
       {
         "label": "final-reboot",

--- a/quanta-d51-2u/workflows/write-quanta-bios-nvram-graph.json
+++ b/quanta-d51-2u/workflows/write-quanta-bios-nvram-graph.json
@@ -52,7 +52,8 @@
         "taskName": "Task.Evaluate.Condition",
         "waitOn": {
           "upgrade-nvram-firmware": "finished"
-        }
+        },
+        "ignoreFailure": true
       },
       {
         "label": "final-reboot",

--- a/quanta-t41/workflows/flash-quanta-bios-graph.json
+++ b/quanta-t41/workflows/flash-quanta-bios-graph.json
@@ -61,7 +61,8 @@
         "taskName": "Task.Evaluate.Condition",
         "waitOn": {
           "catalog-quanta-bios-after": "finished"
-        }
+        },
+        "ignoreFailure": true
       },
       {
         "label": "final-reboot",

--- a/quanta-t41/workflows/flash-quanta-bmc-graph.json
+++ b/quanta-t41/workflows/flash-quanta-bmc-graph.json
@@ -71,7 +71,8 @@
         "taskName": "Task.Evaluate.Condition",
         "waitOn": {
           "catalog-quanta-bmc-after": "finished"
-        }
+        },
+        "ignoreFailure": true
       },
       {
         "label": "final-reboot",

--- a/quanta-t41/workflows/write-quanta-bios-nvram-graph.json
+++ b/quanta-t41/workflows/write-quanta-bios-nvram-graph.json
@@ -52,7 +52,8 @@
         "taskName": "Task.Evaluate.Condition",
         "waitOn": {
           "upgrade-nvram-firmware": "finished"
-        }
+        },
+        "ignoreFailure": true
       },
       {
         "label": "final-reboot",


### PR DESCRIPTION
Fix ODR-888 and 828

Add "ignore failure" in FW update workflow so that the workflow can finish when "evaluate condition" task is false, otherwise the workflow runs forever. 

@VulpesArtificem made a fix about finishing a workflow when one of the terminal task failed but it is configured as "ignoreFailure". (https://github.com/RackHD/on-core/pull/213, https://github.com/RackHD/on-tasks/pull/344, https://github.com/RackHD/on-taskgraph/pull/172) Add this configuration in all FW update workflows.
