### PR TITLE
WIP: Version Control in Bintray

### DIFF
--- a/.bintray-deb.json.in
+++ b/.bintray-deb.json.in
@@ -1,18 +1,20 @@
 {
     "package": {
-        "name": "packages",
-        "repo": "debian",
-        "subject": "rackhd"
+        "name": "on-skupack",
+        "repo": "#DEB_REPO_NAME#",
+        "subject": "panpan0000",
+        "vcs_url": "https://github.com/RackHD/on-skupack.git",
+        "licenses": ["Apache-2.0"]
     },
 
     "version": {
-        "name": "master"
+        "name": "#REVISION#"
     },
 
     "files":
     [
         {
-            "includePattern": "deb/(.*)", "uploadPattern": "dists/trusty/main/binary-amd64/$1",
+            "includePattern": "deb/(.*)", "uploadPattern": "dists/trusty/main/binary-amd64/#REVISION#/$1",
             "matrixParams":
             {
                 "override": 1,

--- a/.bintray-gen.json.in
+++ b/.bintray-gen.json.in
@@ -1,12 +1,14 @@
 {
     "package": {
         "name": "on-skupack",
-        "repo": "binary",
-        "subject": "rackhd"
+        "repo": "#STATIC_REPO_NAME#",
+        "subject": "panpan0000",
+        "vcs_url": "https://github.com/RackHD/on-skupack.git",
+        "licenses": ["Apache-2.0"]
     },
 
     "version": {
-        "name": "master"
+        "name": "#REVISION#"
     },
 
     "files":

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: bash 
 sudo: true
 dist: trusty
+
 addons:
   apt:
     packages:
@@ -10,8 +11,10 @@ addons:
       - git
 
 before_deploy:
- - ./build-package.bash quanta-d51 "${TRAVIS_BRANCH}"
+ - ./build-package.bash quanta-d51-1u "${TRAVIS_BRANCH}"
+ - ./build-package.bash quanta-d51-2u "${TRAVIS_BRANCH}"
  - ./build-package.bash quanta-t41 "${TRAVIS_BRANCH}"
+ - ./gen_bintray_cfg.bash   "${TRAVIS_BRANCH}"
  - if [ ! -e deb ]; then mkdir deb && cp -a *.deb deb/; fi
 
 deploy:
@@ -20,13 +23,13 @@ deploy:
     user: $BINTRAY_USER
     key: $BINTRAY_KEY
     on:
-      branch: master
+        all_branches: true
   - provider: bintray
     file: .bintray-gen.json
     user: $BINTRAY_USER
     key: $BINTRAY_KEY
     on:
-      branch: master
+        all_branches: true
 
 notifications:
   slack:

--- a/build-package.bash
+++ b/build-package.bash
@@ -1,34 +1,51 @@
 #!/bin/bash
-DEBDIR="./debianstatic"
-BRANCH=${2}
+
+#
+# Parameter{1} SKU_DIR: the vendor folder to be build [must have]
+# Parameter{2} the branch being build[ optional ]
+#
+#
 set -x
+set -e
+DEBDIR="./debianstatic"
+SKU_DIR=${1}
+BRANCH=${2}
 
 if [ ! -d "${DEBDIR}" ]; then 
     echo "no such debian directory ${DEBDIR}"
     exit 1 
 fi
 
+if [ ! -d  ${SKU_DIR} ]; then
+    echo "[Error] No such vendor folder found :${SKU_DIR}"
+    exit 2
+fi
 
-rm -rf ${1}_*
+
+rm -rf ${SKU_DIR}_*
 rm -rf packagebuild
 mkdir -p packagebuild/debian 
 
 
-git log -1 --pretty=format:%h.%ai.%s ${1} > commitstring.txt
-export DEBFULLNAME=`git log -1 --pretty=format:%an ${1}`
-export DEBEMAIL=`git log -1 --pretty=format:%ae ${1}`
-export DEBBRANCH=`echo "${BRANCH}" | sed 's/[\/\_]/-/g'`  
-export DEBPKGVER=`git log -1 --pretty=oneline --abbrev-commit ${1}`
+git log -1 --pretty=format:%h.%ai.%s ${SKU_DIR} > commitstring.txt
+export DEBFULLNAME=`git log -1 --pretty=format:%an ${SKU_DIR}`
+export DEBEMAIL=`git log -1 --pretty=format:%ae ${SKU_DIR}`
+export DEBBRANCH=`echo "${BRANCH}" | sed 's/[\/\_]/-/g'`
+export DEBCOMMIT_DATE=`git log -1 --pretty=format:%ai ${SKU_DIR} |awk '{print $1}' `
+export DEBCOMMIT_HASH=`git log -1 --pretty=format:%h ${SKU_DIR}`
+export DEBCOMMIT=`git log -1 --pretty=oneline --abbrev-commit ${SKU_DIR}`
+#export DEBPKGVER=-${DEBBRANCH}${DEBCOMMIT_DATE}-${DEBCOMMIT_HASH} # abondon $DEBBRANCH, since the strategy is to modify the debian/changelog for each release-branch
+export DEBPKGVER=-${DEBCOMMIT_DATE}-${DEBCOMMIT_HASH}
 
-pushd ${1}
-tar czf ../packagebuild/${1}.tar.gz *
+pushd ${SKU_DIR}
+tar czf ../packagebuild/${SKU_DIR}.tar.gz *
 popd
 
 pushd packagebuild
 rsync -ar ../${DEBDIR}/ debian/
 
 cat > /tmp/sed.script << EOF
-s%{{name}}%${1}%
+s%{{name}}%${SKU_DIR}%
 EOF
 
 find . -type f -iname "*.in" -print0 | while IFS= read -r -d $'\0' file; do
@@ -38,10 +55,15 @@ find . -type f -iname "*.in" -print0 | while IFS= read -r -d $'\0' file; do
 done
 rm /tmp/sed.script
 
-dch -l "${DEBBRANCH}" -u low "${DEBPKGVER}"
+################################################################################
+# dch=debchange
+# -l : Add a suffix to the Debian version number for a local build
+# text(${DEBPKGVER}) : a string in changelog for this new local debian version(packagebuild/debian/changelog)
+###############################################################################
+dch -l "${DEBPKGVER}" -u low "${DEBCOMMIT}"
 debuild --no-lintian --no-tgz-check -us -uc
 popd
 
-mkdir -p tarballs && mv packagebuild/${1}.tar.gz tarballs/${1}_${DEBBRANCH}.tar.gz
+mkdir -p tarballs && mv packagebuild/${SKU_DIR}.tar.gz tarballs/${SKU_DIR}${DEBPKGVER}.tar.gz
 
 ls -l .

--- a/gen_bintray_cfg.bash
+++ b/gen_bintray_cfg.bash
@@ -1,0 +1,65 @@
+#!/bin/bash
+#############################################################################
+#
+#  This script will generate bintray config for TravisCI, based a template .in file.
+#  specifically, this script will point the bintray config to correct bintray repo,
+#  and use an identical package name as version control.
+#
+#  PARAM {1} : Branch . it's used to find corresponding bintray repo and name a package
+#
+############################################################################
+set -e
+
+BRANCH=${1}
+
+if [ ! -n "$BRANCH" ]; then
+    echo "[Error] The first parameter should be given. it's the BRANCH which you are standing on."
+    exit 1
+fi
+
+
+#################################################################
+#
+# The Bintray Packages Version "REPO_PKGVER" is:
+#
+#     branch +   last-commit-date + last-commit-hash
+#
+##################################################################
+REPO_COMMIT_DATE=`git log -1 --pretty=format:%ci  |awk '{print $1}' `
+REPO_COMMIT_HASH=`git log -1 --pretty=format:%h `
+REPO_PKGVER=${BRANCH}-${REPO_COMMIT_DATE}-${REPO_COMMIT_HASH}
+
+
+###################################################################
+#  for example, if build from master branch:
+#  the debian target repo is: $DEB_REPO_PREFIX     + master.
+#  the static  target repo is: $STATIC_REPO_PREFIX + master
+#
+#  Important NOTE: Before the TravisCI runs, user should ensure that the above repos exist.
+#            Travis CI will NOT create a repo for you. but only will create a package/version for you.
+#
+##################################################################
+STATIC_REPO_PREFIX="static-"
+DEB_REPO_PREFIX="deb-"
+
+##################################################################
+# replace the reserved fields Surrounding by '##'
+#
+# typically 
+#       - #STATIC_REPO_NAME#   : static images repo name in bintray, the type is generic
+#       - #DEB_REPO_NAME#      : debian repository name in bintray
+#       - #REVISION#           : a new package version (Note the Package term in Bintray)
+#
+##################################################################
+for template in $(ls -a .bintray*.in); do
+    sed  -e "s/#STATIC_REPO_NAME#/${STATIC_REPO_PREFIX}${BRANCH}/g" \
+         -e    "s/#DEB_REPO_NAME#/${DEB_REPO_PREFIX}${BRANCH}/g" \
+         -e         "s/#REVISION#/${REPO_PKGVER}/g"  \
+         ${template}       > ${template%.*}
+
+    cat ${template%.*}   # ${filename%.*} aims to remove the last ".in" prefix of the template file
+done
+
+
+
+


### PR DESCRIPTION
a.  deb-package will be named with “branch-date-hash” convention. Same as  skupack.zip /
example:

```
on-skupack-dell-c6320_1.1-1-2016-09-02-34294f31_amd64.deb
on-skupack-quanta-d51-1u_1.1-1-2016-09-23-9e6f7d11_amd64.deb
```

b.  When uploading to bintray,  they will all be uploaded to 

```
dists/trusty/main/binary-amd64/${ branch-date-hash}/ 
```

detail in https://groups.google.com/forum/#!topic/rackhd/fEtZVKjKmZ0

@zyoung51 , @RackHD/doccommitters
