### PR TITLE
use overlayfsUri to replace overlayfs

### DIFF
--- a/dell-c6320/workflows/dell-discovery-graph.json
+++ b/dell-c6320/workflows/dell-discovery-graph.json
@@ -3,7 +3,7 @@
     "injectableName": "Graph.Dell.Discovery",
     "options": {
         "bootstrap-ubuntu": {
-            "overlayfs": "common/dell.raid.overlay.cpio.gz"
+            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz"
         }
     },
     "tasks": [

--- a/dell-c6320/workflows/dell-perccli-create-megaraid-graph.json
+++ b/dell-c6320/workflows/dell-perccli-create-megaraid-graph.json
@@ -3,7 +3,7 @@
     "injectableName": "Graph.Raid.Create.Perccli",
     "options": {
         "bootstrap-ubuntu": {
-            "overlayfs": "common/dell.raid.overlay.cpio.gz"
+            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz"
         },
         "create-raid": {
             "path": "/opt/MegaRAID/perccli/perccli64"

--- a/dell-c6320/workflows/dell-perccli-delete-megaraid-graph.json
+++ b/dell-c6320/workflows/dell-perccli-delete-megaraid-graph.json
@@ -3,7 +3,7 @@
     "injectableName": "Graph.Raid.Delete.Perccli",
     "options": {
         "bootstrap-ubuntu": {
-            "overlayfs": "common/dell.raid.overlay.cpio.gz"
+            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz"
         },
         "delete-raid": {
             "path": "/opt/MegaRAID/perccli/perccli64"

--- a/dell-c6320/workflows/dell-perccli-megaraid-catalog.json
+++ b/dell-c6320/workflows/dell-perccli-megaraid-catalog.json
@@ -3,7 +3,7 @@
     "injectableName": "Graph.Dell.perccli.Catalog",
     "options": {
         "bootstrap-ubuntu": {
-            "overlayfs": "common/dell.raid.overlay.cpio.gz"
+            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz"
         }
     },
     "tasks": [

--- a/dell-r630/workflows/dell-discovery-graph.json
+++ b/dell-r630/workflows/dell-discovery-graph.json
@@ -3,7 +3,7 @@
     "injectableName": "Graph.Dell.Discovery",
     "options": {
         "bootstrap-ubuntu": {
-            "overlayfs": "common/dell.raid.overlay.cpio.gz"
+            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz"
         }
     },
     "tasks": [

--- a/dell-r630/workflows/dell-perccli-create-megaraid-graph.json
+++ b/dell-r630/workflows/dell-perccli-create-megaraid-graph.json
@@ -3,7 +3,7 @@
     "injectableName": "Graph.Raid.Create.Perccli",
     "options": {
         "bootstrap-ubuntu": {
-            "overlayfs": "common/dell.raid.overlay.cpio.gz"
+            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz"
         },
         "create-raid": {
             "path": "/opt/MegaRAID/perccli/perccli64"

--- a/dell-r630/workflows/dell-perccli-delete-megaraid-graph.json
+++ b/dell-r630/workflows/dell-perccli-delete-megaraid-graph.json
@@ -3,7 +3,7 @@
     "injectableName": "Graph.Raid.Delete.Perccli",
     "options": {
         "bootstrap-ubuntu": {
-            "overlayfs": "common/dell.raid.overlay.cpio.gz"
+            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz"
         },
         "delete-raid": {
             "path": "/opt/MegaRAID/perccli/perccli64"

--- a/dell-r630/workflows/dell-perccli-megaraid-catalog.json
+++ b/dell-r630/workflows/dell-perccli-megaraid-catalog.json
@@ -3,7 +3,7 @@
     "injectableName": "Graph.Dell.perccli.Catalog",
     "options": {
         "bootstrap-ubuntu": {
-            "overlayfs": "common/dell.raid.overlay.cpio.gz"
+            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz"
         }
     },
     "tasks": [

--- a/dell-r730/workflows/dell-discovery-graph.json
+++ b/dell-r730/workflows/dell-discovery-graph.json
@@ -3,7 +3,7 @@
     "injectableName": "Graph.Dell.Discovery",
     "options": {
         "bootstrap-ubuntu": {
-            "overlayfs": "common/dell.raid.overlay.cpio.gz"
+            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz"
         }
     },
     "tasks": [

--- a/dell-r730/workflows/dell-perccli-create-megaraid-graph.json
+++ b/dell-r730/workflows/dell-perccli-create-megaraid-graph.json
@@ -3,7 +3,7 @@
     "injectableName": "Graph.Raid.Create.Perccli",
     "options": {
         "bootstrap-ubuntu": {
-            "overlayfs": "common/dell.raid.overlay.cpio.gz"
+            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz"
         },
         "create-raid": {
             "path": "/opt/MegaRAID/perccli/perccli64"

--- a/dell-r730/workflows/dell-perccli-delete-megaraid-graph.json
+++ b/dell-r730/workflows/dell-perccli-delete-megaraid-graph.json
@@ -3,7 +3,7 @@
     "injectableName": "Graph.Raid.Delete.Perccli",
     "options": {
         "bootstrap-ubuntu": {
-            "overlayfs": "common/dell.raid.overlay.cpio.gz"
+            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz"
         },
         "delete-raid": {
             "path": "/opt/MegaRAID/perccli/perccli64"

--- a/dell-r730/workflows/dell-perccli-megaraid-catalog.json
+++ b/dell-r730/workflows/dell-perccli-megaraid-catalog.json
@@ -3,7 +3,7 @@
     "injectableName": "Graph.Dell.perccli.Catalog",
     "options": {
         "bootstrap-ubuntu": {
-            "overlayfs": "common/dell.raid.overlay.cpio.gz"
+            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz"
         }
     },
     "tasks": [

--- a/dell-r730xd/workflows/dell-discovery-graph.json
+++ b/dell-r730xd/workflows/dell-discovery-graph.json
@@ -3,7 +3,7 @@
     "injectableName": "Graph.Dell.Discovery",
     "options": {
         "bootstrap-ubuntu": {
-            "overlayfs": "common/dell.raid.overlay.cpio.gz"
+            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz"
         }
     },
     "tasks": [

--- a/dell-r730xd/workflows/dell-perccli-create-megaraid-graph.json
+++ b/dell-r730xd/workflows/dell-perccli-create-megaraid-graph.json
@@ -3,7 +3,7 @@
     "injectableName": "Graph.Raid.Create.Perccli",
     "options": {
         "bootstrap-ubuntu": {
-            "overlayfs": "common/dell.raid.overlay.cpio.gz"
+            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz"
         },
         "create-raid": {
             "path": "/opt/MegaRAID/perccli/perccli64"

--- a/dell-r730xd/workflows/dell-perccli-delete-megaraid-graph.json
+++ b/dell-r730xd/workflows/dell-perccli-delete-megaraid-graph.json
@@ -3,7 +3,7 @@
     "injectableName": "Graph.Raid.Delete.Perccli",
     "options": {
         "bootstrap-ubuntu": {
-            "overlayfs": "common/dell.raid.overlay.cpio.gz"
+            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz"
         },
         "delete-raid": {
             "path": "/opt/MegaRAID/perccli/perccli64"

--- a/dell-r730xd/workflows/dell-perccli-megaraid-catalog.json
+++ b/dell-r730xd/workflows/dell-perccli-megaraid-catalog.json
@@ -3,7 +3,7 @@
     "injectableName": "Graph.Dell.perccli.Catalog",
     "options": {
         "bootstrap-ubuntu": {
-            "overlayfs": "common/dell.raid.overlay.cpio.gz"
+            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz"
         }
     },
     "tasks": [


### PR DESCRIPTION
Node discovery fails when using static file server, because basefs and overlayfs are always pulled from API_CB(api.server) rather than file.server.
The solution is to change BASEFS and OVERLAYFS to be full URL instead of file path.
- use overlayfsUri and overlayfsFile to replace overlayfs in task options
- use basefsUri and basefsFile to replace basefs in task options

@RackHD/corecommitters @iceiilin @cgx027 @panpan0000 
