### PR TITLE
updating skupacks to use /api/current in route path

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Maintain SKU specific package content such as templates and other static files.
 * Register a new SKU with the package
 
   ```
-  $ curl -X POST -F file=@tarballs/sku_pack_directory_subname.tar.gz localhost:8080/api/common/skus/pack
+  $ curl -X POST -F file=@tarballs/sku_pack_directory_subname.tar.gz localhost:8080/api/current/skus/pack
   ```
 
 * Please refer to [SKU PACK Guide](http://rackhd.readthedocs.org/en/latest/rackhd/index.html#workflow-sku-support) for more API commands

--- a/arista-dcs-7124S/workflows/deploy-startup-config-graph.json
+++ b/arista-dcs-7124S/workflows/deploy-startup-config-graph.json
@@ -16,7 +16,7 @@
                 "options": {
                     "commands": [
                         {
-                            "downloadUrl": "/api/1.1/templates/arista-catalog-ip.py",
+                            "downloadUrl": "/api/current/templates/arista-catalog-ip.py",
                             "catalog": { "format": "json", "source": "ip" }
                         }
                     ]
@@ -56,7 +56,7 @@
                     "switchIp": "{{ context.ip.internetAddress }}",
                     "commands": [
                         {
-                            "downloadUrl": "/api/1.1/templates/arista-deploy-startup-config.py"
+                            "downloadUrl": "/api/current/templates/arista-deploy-startup-config.py"
                         }
                     ]
                 },

--- a/cisco-nexus-C3132/workflows/deploy-startup-config-boot-images-graph.json
+++ b/cisco-nexus-C3132/workflows/deploy-startup-config-boot-images-graph.json
@@ -25,7 +25,7 @@
                     "bootImageUri": "{{ api.server }}/{{ options.staticDir }}/{{ options.bootImage }}",
                     "commands": [
                         {
-                            "downloadUrl": "/api/1.1/templates/cisco-deploy-config-and-images.py"
+                            "downloadUrl": "/api/current/templates/cisco-deploy-config-and-images.py"
                         }
                     ]
                 },
@@ -41,7 +41,7 @@
                 "options": {
                     "commands": [
                         {
-                            "downloadUrl": "/api/1.1/templates/cisco-catalog-config.py",
+                            "downloadUrl": "/api/current/templates/cisco-catalog-config.py",
                             "catalog": { "format": "json", "source": "config" }
                         }
                     ]

--- a/debianstatic/postinst.in
+++ b/debianstatic/postinst.in
@@ -1,7 +1,7 @@
 #!/bin/bash
 FILE=/var/renasar/on-http/.skupack/{{name}}.tar.gz
 SKUFILE=/var/renasar/on-http/.skupack/{{name}}.sku
-CODE=`curl -s -X POST --data-binary @${FILE} -o ${SKUFILE} -w '%{http_code}' localhost:8080/api/common/skus/pack`
+CODE=`curl -s -X POST --data-binary @${FILE} -o ${SKUFILE} -w '%{http_code}' localhost:8080/api/current/skus/pack`
 if [ ${CODE} == 201 ]; then
   echo SKU Pack registered as SKU: ${SKUID}
   rm -f ${FILE}

--- a/debianstatic/postrm.in
+++ b/debianstatic/postrm.in
@@ -3,7 +3,7 @@ set -e
 SKUFILE=/var/renasar/on-http/.skupack/{{name}}.sku
 if [ -f ${SKUFILE} ]; then
   SKUID=`cat ${SKUFILE}`
-  curl -X DELETE localhost:8080/api/common/skus/${SKUID}/pack
+  curl -X DELETE localhost:8080/api/current/skus/${SKUID}/pack
   rm /var/renasar/on-http/.skupack/{{name}}.sku
 fi
 

--- a/quanta-d51-2u/README.md
+++ b/quanta-d51-2u/README.md
@@ -10,7 +10,7 @@
 **Run a BIOS upgrade against a node**
 ```
 POST
-/api/1.1/nodes/<id>/workflows
+/api/current/nodes/<id>/workflows
 {
     "name": "Graph.Flash.Quanta.BIOS"
 }
@@ -19,7 +19,7 @@ POST
 **Run a BIOS upgrade against a node without rebooting at the end**
 ```
 POST
-/api/1.1/nodes/<id>/workflows
+/api/current/nodes/<id>/workflows
 {
     "name": "Graph.Flash.Quanta.BIOS"
     "options": {
@@ -32,7 +32,7 @@ POST
 **Run a BIOS upgrade against a node with a file override**
 ```
 POST
-/api/1.1/nodes/<id>/workflows
+/api/current/nodes/<id>/workflows
 {
     "name": "Graph.Flash.Quanta.BIOS"
     "options": {
@@ -59,7 +59,7 @@ curl -X PUT -T file.img http://localhost:8080/api/current/files/file.img
 **Run a BMC upgrade against a node**
 ```
 POST
-/api/1.1/nodes/<id>/workflows
+/api/current/nodes/<id>/workflows
 {
     "name": "Graph.Flash.Quanta.Bmc"
 }
@@ -68,7 +68,7 @@ POST
 **Run a BMC upgrade against a node without rebooting at the end**
 ```
 POST
-/api/1.1/nodes/<id>/workflows
+/api/current/nodes/<id>/workflows
 {
     "name": "Graph.Flash.Quanta.Bmc"
     "options": {
@@ -81,7 +81,7 @@ POST
 **Run a BMC upgrade against a node with a file override**
 ```
 POST
-/api/1.1/nodes/<id>/workflows
+/api/current/nodes/<id>/workflows
 {
     "name": "Graph.Flash.Quanta.Bmc"
     "options": {

--- a/quanta-d51-2u/workflows/flash-quanta-bios-graph.json
+++ b/quanta-d51-2u/workflows/flash-quanta-bios-graph.json
@@ -39,7 +39,7 @@
             "commands": [
               {
                 "command": "sudo ./flash_bios.sh",
-                "downloadUrl": "/api/1.1/templates/flash_bios.sh"
+                "downloadUrl": "/api/current/templates/flash_bios.sh"
               }
             ]
           },

--- a/quanta-d51-2u/workflows/flash-quanta-bmc-graph.json
+++ b/quanta-d51-2u/workflows/flash-quanta-bmc-graph.json
@@ -49,7 +49,7 @@
             "commands": [
               {
                 "command": "sudo ./flash_bmc.sh",
-                "downloadUrl": "/api/1.1/templates/flash_bmc.sh"
+                "downloadUrl": "/api/current/templates/flash_bmc.sh"
               }
             ]
           },

--- a/quanta-d51-2u/workflows/write-quanta-bios-nvram-graph.json
+++ b/quanta-d51-2u/workflows/write-quanta-bios-nvram-graph.json
@@ -37,7 +37,7 @@
             "commands": [
               {
                 "command": "sudo ./flash_nvram.sh",
-                "downloadUrl": "/api/1.1/templates/flash_nvram.sh"
+                "downloadUrl": "/api/current/templates/flash_nvram.sh"
               }
             ]
           },

--- a/quanta-t41/README.md
+++ b/quanta-t41/README.md
@@ -11,7 +11,7 @@
 **Run a BIOS upgrade against a node**
 ```
 POST
-/api/1.1/nodes/<id>/workflows
+/api/current/nodes/<id>/workflows
 {
     "name": "Graph.Flash.Quanta.BIOS"
 }
@@ -20,7 +20,7 @@ POST
 **Run a BIOS upgrade against a node without rebooting at the end**
 ```
 POST
-/api/1.1/nodes/<id>/workflows
+/api/current/nodes/<id>/workflows
 {
     "name": "Graph.Flash.Quanta.BIOS"
     "options": {
@@ -33,7 +33,7 @@ POST
 **Run a BIOS upgrade against a node with a file override**
 ```
 POST
-/api/1.1/nodes/<id>/workflows
+/api/current/nodes/<id>/workflows
 {
     "name": "Graph.Flash.Quanta.BIOS"
     "options": {
@@ -62,7 +62,7 @@ curl -X PUT -T file.img http://localhost:8080/api/current/files/file.img
  **Run a BMC upgrade against a node**
 ```
 POST
-/api/1.1/nodes/<id>/workflows
+/api/current/nodes/<id>/workflows
 {
     "name": "Graph.Flash.Quanta.Bmc"
 }
@@ -71,7 +71,7 @@ POST
 **Run a BMC upgrade against a node without rebooting at the end**
 ```
 POST
-/api/1.1/nodes/<id>/workflows
+/api/current/nodes/<id>/workflows
 {
     "name": "Graph.Flash.Quanta.Bmc"
     "options": {
@@ -84,7 +84,7 @@ POST
 **Run a BMC upgrade against a node with a file override**
 ```
 POST
-/api/1.1/nodes/<id>/workflows
+/api/current/nodes/<id>/workflows
 {
     "name": "Graph.Flash.Quanta.Bmc"
     "options": {

--- a/quanta-t41/workflows/flash-quanta-bios-graph.json
+++ b/quanta-t41/workflows/flash-quanta-bios-graph.json
@@ -39,7 +39,7 @@
             "commands": [
               {
                 "command": "sudo ./flash_bios.sh",
-                "downloadUrl": "/api/1.1/templates/flash_bios.sh"
+                "downloadUrl": "/api/current/templates/flash_bios.sh"
               }
             ]
           },

--- a/quanta-t41/workflows/flash-quanta-bmc-graph.json
+++ b/quanta-t41/workflows/flash-quanta-bmc-graph.json
@@ -49,7 +49,7 @@
             "commands": [
               {
                 "command": "sudo ./flash_bmc.sh",
-                "downloadUrl": "/api/1.1/templates/flash_bmc.sh"
+                "downloadUrl": "/api/current/templates/flash_bmc.sh"
               }
             ]
           },

--- a/quanta-t41/workflows/write-quanta-bios-nvram-graph.json
+++ b/quanta-t41/workflows/write-quanta-bios-nvram-graph.json
@@ -37,7 +37,7 @@
             "commands": [
               {
                 "command": "sudo ./flash_nvram.sh",
-                "downloadUrl": "/api/1.1/templates/flash_nvram.sh"
+                "downloadUrl": "/api/current/templates/flash_nvram.sh"
               }
             ]
           },


### PR DESCRIPTION
making updates to on-skupack to replace instances of /api/1.1 or /api/common to /api/current.

@RackHD/corecommitters @dalebremner @geoff-reid @srinia6 @zyoung51 
