### PR TITLE
Fix for Brocade sku pack json syntax error

### DIFF
--- a/brocade-VDX-6740/config.json
+++ b/brocade-VDX-6740/config.json
@@ -2,7 +2,7 @@
      "name": "Brocade VDX SKU",
      "rules": [
          {
-             "regex": "Hardware Rev\s*: 131\.7",
+             "regex": "Hardware Rev\\s*: 131\\.7",
              "path": "version"
          }
      ],

--- a/brocade-VDX-6740T/config.json
+++ b/brocade-VDX-6740T/config.json
@@ -2,7 +2,7 @@
      "name": "Brocade VDX SKU",
      "rules": [
          {
-             "regex": "Hardware Rev\s*: 137\.4",
+             "regex": "Hardware Rev\\s*: 137\\.4",
              "path": "version"
          }
      ],


### PR DESCRIPTION
Fixed the control character syntax so it is in valid json format in order to load the sku pack.

The following regex string in the two brocade SKU packs result in an invalid json format.
This causes the loading of the sku pack via the RackHD API to fail.
```		
"regex": "Hardware Rev\s*: 137\.4",

Error: Parse error on line 4:
...les": [{		"regex": "Hardware Rev\s*: 13
----------------------^
Expecting 'STRING', 'NUMBER', 'NULL', 'TRUE', 'FALSE', '{', '[', got 'undefined'
```
Fixed using via the following and tested loading of the sku packs works.
```
"regex": "Hardware Rev\\s*: 137\\.4",
```
Since I don't have a brocad switch handy, I tested the regex format of the "\\s" in another sku pack for Hydra, 
by switching one of the rules like this to verify the string gets parsed correctly during node disovery and sku matching.
ie
```. 
{
    "httpStaticRoot": "static",
    "httpTemplateRoot": "templates",
    "id": "1eed137f-447b-425e-b8b4-ab659607bba3",
    "name": "Hydra",
    "rules": [
        {
            "path": "ipmi-fru.Basbrd Mgmt Ctlr.Board Mfg",
            "regex": "Intel\\s*"
        },
        {
            "equals": "S2600WTT",
            "path": "ipmi-fru.Basbrd Mgmt Ctlr.Product Name"
        },
        {
            "path": "ipmi-fru.HS Backplane 1 (ID 5).Board Part Number",
            "regex": "(G97164|G97156)-(\\d{3})"
        }
    ],
```
Discovered and sku matched the Hydra node ok.
