### PR TITLE
 Add secure erase graph to dell sku packs

### DIFF
--- a/dell-c6320/workflows/dell-secure-erase-drive-graph.json
+++ b/dell-c6320/workflows/dell-secure-erase-drive-graph.json
@@ -1,0 +1,105 @@
+{
+    "friendlyName": "Secure Erase Drive",
+    "injectableName": "Graph.Drive.SecureErase",
+    "options": {
+        "bootstrap-ubuntu": {
+            "overlayfsFile": "secure.erase.overlay.cpio.gz",
+            "triggerGroup": "secureErase"
+        },
+        "drive-scan-delay": {
+            "duration": 10000
+        },
+        "drive-secure-erase": {
+            "eraseSettings": null
+        },
+        "finish-bootstrap-trigger": {
+            "triggerGroup": "secureErase"
+        }
+    },
+    "tasks": [
+        {
+            "label": "cache-driveId-catalog",
+            "taskName": "Task.Get.DriveId.Catalog"
+        },
+        {
+            "ignoreFailure": true,
+            "label": "set-boot-pxe",
+            "taskName": "Task.Obm.Node.PxeBoot",
+            "waitOn": {
+                "cache-driveId-catalog": "succeeded"
+            }
+        },
+        {
+            "label": "reboot",
+            "taskName": "Task.Obm.Node.Reboot",
+            "waitOn": {
+                "set-boot-pxe": "finished"
+            }
+        },
+        {
+            "label": "bootstrap-ubuntu",
+            "taskName": "Task.Linux.Bootstrap.Ubuntu",
+            "waitOn": {
+                "reboot": "succeeded"
+            }
+        },
+        {
+            "label": "drive-scan-delay",
+            "taskName": "Task.Node.Sleep",
+            "waitOn": {
+                "reboot": "succeeded"
+            }
+        },
+        {
+            "label": "catalog-driveid-before",
+            "taskName": "Task.Catalog.Drive.Id",
+            "waitOn": {
+                "drive-scan-delay": "succeeded"
+            }
+        },
+        {
+            "label": "catalog-megaraid-before",
+            "taskName": "Task.Catalog.perccli",
+            "waitOn": {
+                "catalog-driveid-before": "succeeded"
+            }
+        },
+        {
+            "label": "drive-secure-erase",
+            "taskName": "Task.Drive.SecureErase",
+            "waitOn": {
+                "catalog-megaraid-before": "succeeded"
+            }
+        },
+        {
+            "ignoreFailure": true,
+            "label": "catalog-megaraid-after",
+            "taskName": "Task.Catalog.perccli",
+            "waitOn": {
+                "drive-secure-erase": "succeeded"
+            }
+        },
+        {
+            "ignoreFailure": true,
+            "label": "catalog-driveid-after",
+            "taskName": "Task.Catalog.Drive.Id",
+            "waitOn": {
+                "catalog-megaraid-after": "finished"
+            }
+        },
+        {
+            "label": "shell-reboot",
+            "taskName": "Task.ProcShellReboot",
+            "waitOn": {
+                "catalog-driveid-after": "finished"
+            }
+        },
+        {
+            "label": "finish-bootstrap-trigger",
+            "taskName": "Task.Trigger.Send.Finish",
+            "waitOn": {
+                "catalog-driveid": "finished"
+            }
+        }
+    ]
+}

--- a/dell-r630/workflows/dell-secure-erase-drive-graph.json
+++ b/dell-r630/workflows/dell-secure-erase-drive-graph.json
@@ -1,0 +1,105 @@
+{
+    "friendlyName": "Secure Erase Drive",
+    "injectableName": "Graph.Drive.SecureErase",
+    "options": {
+        "bootstrap-ubuntu": {
+            "overlayfsFile": "secure.erase.overlay.cpio.gz",
+            "triggerGroup": "secureErase"
+        },
+        "drive-scan-delay": {
+            "duration": 10000
+        },
+        "drive-secure-erase": {
+            "eraseSettings": null
+        },
+        "finish-bootstrap-trigger": {
+            "triggerGroup": "secureErase"
+        }
+    },
+    "tasks": [
+        {
+            "label": "cache-driveId-catalog",
+            "taskName": "Task.Get.DriveId.Catalog"
+        },
+        {
+            "ignoreFailure": true,
+            "label": "set-boot-pxe",
+            "taskName": "Task.Obm.Node.PxeBoot",
+            "waitOn": {
+                "cache-driveId-catalog": "succeeded"
+            }
+        },
+        {
+            "label": "reboot",
+            "taskName": "Task.Obm.Node.Reboot",
+            "waitOn": {
+                "set-boot-pxe": "finished"
+            }
+        },
+        {
+            "label": "bootstrap-ubuntu",
+            "taskName": "Task.Linux.Bootstrap.Ubuntu",
+            "waitOn": {
+                "reboot": "succeeded"
+            }
+        },
+        {
+            "label": "drive-scan-delay",
+            "taskName": "Task.Node.Sleep",
+            "waitOn": {
+                "reboot": "succeeded"
+            }
+        },
+        {
+            "label": "catalog-driveid-before",
+            "taskName": "Task.Catalog.Drive.Id",
+            "waitOn": {
+                "drive-scan-delay": "succeeded"
+            }
+        },
+        {
+            "label": "catalog-megaraid-before",
+            "taskName": "Task.Catalog.perccli",
+            "waitOn": {
+                "catalog-driveid-before": "succeeded"
+            }
+        },
+        {
+            "label": "drive-secure-erase",
+            "taskName": "Task.Drive.SecureErase",
+            "waitOn": {
+                "catalog-megaraid-before": "succeeded"
+            }
+        },
+        {
+            "ignoreFailure": true,
+            "label": "catalog-megaraid-after",
+            "taskName": "Task.Catalog.perccli",
+            "waitOn": {
+                "drive-secure-erase": "succeeded"
+            }
+        },
+        {
+            "ignoreFailure": true,
+            "label": "catalog-driveid-after",
+            "taskName": "Task.Catalog.Drive.Id",
+            "waitOn": {
+                "catalog-megaraid-after": "finished"
+            }
+        },
+        {
+            "label": "shell-reboot",
+            "taskName": "Task.ProcShellReboot",
+            "waitOn": {
+                "catalog-driveid-after": "finished"
+            }
+        },
+        {
+            "label": "finish-bootstrap-trigger",
+            "taskName": "Task.Trigger.Send.Finish",
+            "waitOn": {
+                "catalog-driveid": "finished"
+            }
+        }
+    ]
+}

--- a/dell-r730/workflows/dell-secure-erase-drive-graph.json
+++ b/dell-r730/workflows/dell-secure-erase-drive-graph.json
@@ -1,0 +1,105 @@
+{
+    "friendlyName": "Secure Erase Drive",
+    "injectableName": "Graph.Drive.SecureErase",
+    "options": {
+        "bootstrap-ubuntu": {
+            "overlayfsFile": "secure.erase.overlay.cpio.gz",
+            "triggerGroup": "secureErase"
+        },
+        "drive-scan-delay": {
+            "duration": 10000
+        },
+        "drive-secure-erase": {
+            "eraseSettings": null
+        },
+        "finish-bootstrap-trigger": {
+            "triggerGroup": "secureErase"
+        }
+    },
+    "tasks": [
+        {
+            "label": "cache-driveId-catalog",
+            "taskName": "Task.Get.DriveId.Catalog"
+        },
+        {
+            "ignoreFailure": true,
+            "label": "set-boot-pxe",
+            "taskName": "Task.Obm.Node.PxeBoot",
+            "waitOn": {
+                "cache-driveId-catalog": "succeeded"
+            }
+        },
+        {
+            "label": "reboot",
+            "taskName": "Task.Obm.Node.Reboot",
+            "waitOn": {
+                "set-boot-pxe": "finished"
+            }
+        },
+        {
+            "label": "bootstrap-ubuntu",
+            "taskName": "Task.Linux.Bootstrap.Ubuntu",
+            "waitOn": {
+                "reboot": "succeeded"
+            }
+        },
+        {
+            "label": "drive-scan-delay",
+            "taskName": "Task.Node.Sleep",
+            "waitOn": {
+                "reboot": "succeeded"
+            }
+        },
+        {
+            "label": "catalog-driveid-before",
+            "taskName": "Task.Catalog.Drive.Id",
+            "waitOn": {
+                "drive-scan-delay": "succeeded"
+            }
+        },
+        {
+            "label": "catalog-megaraid-before",
+            "taskName": "Task.Catalog.perccli",
+            "waitOn": {
+                "catalog-driveid-before": "succeeded"
+            }
+        },
+        {
+            "label": "drive-secure-erase",
+            "taskName": "Task.Drive.SecureErase",
+            "waitOn": {
+                "catalog-megaraid-before": "succeeded"
+            }
+        },
+        {
+            "ignoreFailure": true,
+            "label": "catalog-megaraid-after",
+            "taskName": "Task.Catalog.perccli",
+            "waitOn": {
+                "drive-secure-erase": "succeeded"
+            }
+        },
+        {
+            "ignoreFailure": true,
+            "label": "catalog-driveid-after",
+            "taskName": "Task.Catalog.Drive.Id",
+            "waitOn": {
+                "catalog-megaraid-after": "finished"
+            }
+        },
+        {
+            "label": "shell-reboot",
+            "taskName": "Task.ProcShellReboot",
+            "waitOn": {
+                "catalog-driveid-after": "finished"
+            }
+        },
+        {
+            "label": "finish-bootstrap-trigger",
+            "taskName": "Task.Trigger.Send.Finish",
+            "waitOn": {
+                "catalog-driveid": "finished"
+            }
+        }
+    ]
+}

--- a/dell-r730xd/workflows/dell-secure-erase-drive-graph.json
+++ b/dell-r730xd/workflows/dell-secure-erase-drive-graph.json
@@ -1,0 +1,105 @@
+{
+    "friendlyName": "Secure Erase Drive",
+    "injectableName": "Graph.Drive.SecureErase",
+    "options": {
+        "bootstrap-ubuntu": {
+            "overlayfsFile": "secure.erase.overlay.cpio.gz",
+            "triggerGroup": "secureErase"
+        },
+        "drive-scan-delay": {
+            "duration": 10000
+        },
+        "drive-secure-erase": {
+            "eraseSettings": null
+        },
+        "finish-bootstrap-trigger": {
+            "triggerGroup": "secureErase"
+        }
+    },
+    "tasks": [
+        {
+            "label": "cache-driveId-catalog",
+            "taskName": "Task.Get.DriveId.Catalog"
+        },
+        {
+            "ignoreFailure": true,
+            "label": "set-boot-pxe",
+            "taskName": "Task.Obm.Node.PxeBoot",
+            "waitOn": {
+                "cache-driveId-catalog": "succeeded"
+            }
+        },
+        {
+            "label": "reboot",
+            "taskName": "Task.Obm.Node.Reboot",
+            "waitOn": {
+                "set-boot-pxe": "finished"
+            }
+        },
+        {
+            "label": "bootstrap-ubuntu",
+            "taskName": "Task.Linux.Bootstrap.Ubuntu",
+            "waitOn": {
+                "reboot": "succeeded"
+            }
+        },
+        {
+            "label": "drive-scan-delay",
+            "taskName": "Task.Node.Sleep",
+            "waitOn": {
+                "reboot": "succeeded"
+            }
+        },
+        {
+            "label": "catalog-driveid-before",
+            "taskName": "Task.Catalog.Drive.Id",
+            "waitOn": {
+                "drive-scan-delay": "succeeded"
+            }
+        },
+        {
+            "label": "catalog-megaraid-before",
+            "taskName": "Task.Catalog.perccli",
+            "waitOn": {
+                "catalog-driveid-before": "succeeded"
+            }
+        },
+        {
+            "label": "drive-secure-erase",
+            "taskName": "Task.Drive.SecureErase",
+            "waitOn": {
+                "catalog-megaraid-before": "succeeded"
+            }
+        },
+        {
+            "ignoreFailure": true,
+            "label": "catalog-megaraid-after",
+            "taskName": "Task.Catalog.perccli",
+            "waitOn": {
+                "drive-secure-erase": "succeeded"
+            }
+        },
+        {
+            "ignoreFailure": true,
+            "label": "catalog-driveid-after",
+            "taskName": "Task.Catalog.Drive.Id",
+            "waitOn": {
+                "catalog-megaraid-after": "finished"
+            }
+        },
+        {
+            "label": "shell-reboot",
+            "taskName": "Task.ProcShellReboot",
+            "waitOn": {
+                "catalog-driveid-after": "finished"
+            }
+        },
+        {
+            "label": "finish-bootstrap-trigger",
+            "taskName": "Task.Trigger.Send.Finish",
+            "waitOn": {
+                "catalog-driveid": "finished"
+            }
+        }
+    ]
+}

--- a/dell-r740/workflows/dell-secure-erase-drive-graph.json
+++ b/dell-r740/workflows/dell-secure-erase-drive-graph.json
@@ -1,0 +1,105 @@
+{
+    "friendlyName": "Secure Erase Drive",
+    "injectableName": "Graph.Drive.SecureErase",
+    "options": {
+        "bootstrap-ubuntu": {
+            "overlayfsFile": "secure.erase.overlay.cpio.gz",
+            "triggerGroup": "secureErase"
+        },
+        "drive-scan-delay": {
+            "duration": 10000
+        },
+        "drive-secure-erase": {
+            "eraseSettings": null
+        },
+        "finish-bootstrap-trigger": {
+            "triggerGroup": "secureErase"
+        }
+    },
+    "tasks": [
+        {
+            "label": "cache-driveId-catalog",
+            "taskName": "Task.Get.DriveId.Catalog"
+        },
+        {
+            "ignoreFailure": true,
+            "label": "set-boot-pxe",
+            "taskName": "Task.Obm.Node.PxeBoot",
+            "waitOn": {
+                "cache-driveId-catalog": "succeeded"
+            }
+        },
+        {
+            "label": "reboot",
+            "taskName": "Task.Obm.Node.Reboot",
+            "waitOn": {
+                "set-boot-pxe": "finished"
+            }
+        },
+        {
+            "label": "bootstrap-ubuntu",
+            "taskName": "Task.Linux.Bootstrap.Ubuntu",
+            "waitOn": {
+                "reboot": "succeeded"
+            }
+        },
+        {
+            "label": "drive-scan-delay",
+            "taskName": "Task.Node.Sleep",
+            "waitOn": {
+                "reboot": "succeeded"
+            }
+        },
+        {
+            "label": "catalog-driveid-before",
+            "taskName": "Task.Catalog.Drive.Id",
+            "waitOn": {
+                "drive-scan-delay": "succeeded"
+            }
+        },
+        {
+            "label": "catalog-megaraid-before",
+            "taskName": "Task.Catalog.perccli",
+            "waitOn": {
+                "catalog-driveid-before": "succeeded"
+            }
+        },
+        {
+            "label": "drive-secure-erase",
+            "taskName": "Task.Drive.SecureErase",
+            "waitOn": {
+                "catalog-megaraid-before": "succeeded"
+            }
+        },
+        {
+            "ignoreFailure": true,
+            "label": "catalog-megaraid-after",
+            "taskName": "Task.Catalog.perccli",
+            "waitOn": {
+                "drive-secure-erase": "succeeded"
+            }
+        },
+        {
+            "ignoreFailure": true,
+            "label": "catalog-driveid-after",
+            "taskName": "Task.Catalog.Drive.Id",
+            "waitOn": {
+                "catalog-megaraid-after": "finished"
+            }
+        },
+        {
+            "label": "shell-reboot",
+            "taskName": "Task.ProcShellReboot",
+            "waitOn": {
+                "catalog-driveid-after": "finished"
+            }
+        },
+        {
+            "label": "finish-bootstrap-trigger",
+            "taskName": "Task.Trigger.Send.Finish",
+            "waitOn": {
+                "catalog-driveid": "finished"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
 * Dell servers use customized tool perccli to get Megaraid catalog thus  a customized secure erase workflow is required to use perccli tool to catalog megaraid information.