### PR TITLE
 Change schemaRef to optionsSchema in quanta folders

### DIFF
--- a/quanta-d51-2u/workflows/flash-quanta-bios-graph.json
+++ b/quanta-d51-2u/workflows/flash-quanta-bios-graph.json
@@ -34,7 +34,7 @@
           "friendlyName": "Upgrade firmware images",
           "injectableName": "Task.Linux.Command.Upgrade.BIOS",
           "implementsTask": "Task.Base.Linux.Commands",
-          "schemaRef": "sku-firmware-update.json", 
+          "optionsSchema": "sku-firmware-update.json",
           "options": {
             "commands": [
               {

--- a/quanta-d51-2u/workflows/flash-quanta-bmc-graph.json
+++ b/quanta-d51-2u/workflows/flash-quanta-bmc-graph.json
@@ -44,7 +44,7 @@
           "friendlyName": "Upgrade firmware images",
           "injectableName": "Task.Linux.Command.Upgrade.Bmc",
           "implementsTask": "Task.Base.Linux.Commands",
-          "schemaRef": "sku-firmware-update.json",
+          "optionsSchema": "sku-firmware-update.json",
           "options": {
             "commands": [
               {

--- a/quanta-t41/workflows/flash-quanta-bios-graph.json
+++ b/quanta-t41/workflows/flash-quanta-bios-graph.json
@@ -34,7 +34,7 @@
           "friendlyName": "Upgrade firmware images",
           "injectableName": "Task.Linux.Command.Upgrade.BIOS",
           "implementsTask": "Task.Base.Linux.Commands",
-          "schemaRef": "sku-firmware-update.json",
+          "optionsSchema": "sku-firmware-update.json",
           "options": {
             "commands": [
               {

--- a/quanta-t41/workflows/flash-quanta-bmc-graph.json
+++ b/quanta-t41/workflows/flash-quanta-bmc-graph.json
@@ -44,7 +44,7 @@
           "friendlyName": "Upgrade firmware images",
           "injectableName": "Task.Linux.Command.Upgrade.Bmc",
           "implementsTask": "Task.Base.Linux.Commands",
-          "schemaRef": "sku-firmware-update.json",  
+          "optionsSchema": "sku-firmware-update.json",
           "options": {
             "commands": [
               {


### PR DESCRIPTION
Background
schemaRef used to be older name for task options schema, it is renamed to optionsSchema later to avoid confusing swagger schema. 

Details
All existing schemaRef is changed to optionsSchema. Mainly in quanta server sku pack.

@iceiilin @anhou @nortonluo 