### PR TITLE
update the driveid when raid changed

### DIFF
--- a/dell-c6320/workflows/dell-perccli-create-megaraid-graph.json
+++ b/dell-c6320/workflows/dell-perccli-create-megaraid-graph.json
@@ -1,4 +1,3 @@
-root@kcps-rackhd01:/home/wangzz/on-skupack/dell-r730/workflows# cat dell-perccli-create-megaraid-graph.json
 {
     "friendlyName": "Create RAID via perccli",
     "injectableName": "Graph.Raid.Create.Perccli",

--- a/dell-c6320/workflows/dell-perccli-create-megaraid-graph.json
+++ b/dell-c6320/workflows/dell-perccli-create-megaraid-graph.json
@@ -1,12 +1,18 @@
+root@kcps-rackhd01:/home/wangzz/on-skupack/dell-r730/workflows# cat dell-perccli-create-megaraid-graph.json
 {
     "friendlyName": "Create RAID via perccli",
     "injectableName": "Graph.Raid.Create.Perccli",
     "options": {
         "bootstrap-ubuntu": {
-            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz"
+            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz",
+            "triggerGroup": "bootstrap"
+        },
+        "finish-bootstrap-trigger":{
+            "triggerGroup": "bootstrap"
         },
         "create-raid": {
-            "path": "/opt/MegaRAID/perccli/perccli64"
+            "path": "/opt/MegaRAID/perccli/perccli64",
+            "createDefault": true
         }
     },
     "tasks": [
@@ -33,7 +39,7 @@
             "label": "create-raid",
             "taskName": "Task.Raid.Create.MegaRAID",
             "waitOn": {
-                "bootstrap-ubuntu": "succeeded"
+                "reboot": "succeeded"
             }
         },
         {
@@ -44,10 +50,24 @@
             }
         },
         {
+            "label": "refresh-catalog-driveid",
+            "taskName": "Task.Catalog.Drive.Id",
+            "waitOn": {
+                "refresh-catalog-megaraid": "succeeded"
+            }
+        },
+        {
+            "label": "finish-bootstrap-trigger",
+            "taskName": "Task.Trigger.Send.Finish",
+            "waitOn": {
+                "final-reboot": "finished"
+            }
+        },
+        {
             "label": "final-reboot",
             "taskName": "Task.Obm.Node.Reboot",
             "waitOn": {
-                "refresh-catalog-megaraid": "finished"
+                "refresh-catalog-driveid": "succeeded"
             }
         }
     ]

--- a/dell-c6320/workflows/dell-perccli-create-megaraid-graph.json
+++ b/dell-c6320/workflows/dell-perccli-create-megaraid-graph.json
@@ -57,17 +57,17 @@ root@kcps-rackhd01:/home/wangzz/on-skupack/dell-r730/workflows# cat dell-perccli
             }
         },
         {
-            "label": "finish-bootstrap-trigger",
-            "taskName": "Task.Trigger.Send.Finish",
-            "waitOn": {
-                "final-reboot": "finished"
-            }
-        },
-        {
             "label": "final-reboot",
             "taskName": "Task.Obm.Node.Reboot",
             "waitOn": {
                 "refresh-catalog-driveid": "succeeded"
+            }
+        },
+        {
+            "label": "finish-bootstrap-trigger",
+            "taskName": "Task.Trigger.Send.Finish",
+            "waitOn": {
+                "final-reboot": "finished"
             }
         }
     ]

--- a/dell-c6320/workflows/dell-perccli-delete-megaraid-graph.json
+++ b/dell-c6320/workflows/dell-perccli-delete-megaraid-graph.json
@@ -3,10 +3,15 @@
     "injectableName": "Graph.Raid.Delete.Perccli",
     "options": {
         "bootstrap-ubuntu": {
-            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz"
+            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz",
+            "triggerGroup": "bootstrap"
+        },
+        "finish-bootstrap-trigger": {
+            "triggerGroup": "bootstrap"
         },
         "delete-raid": {
-            "path": "/opt/MegaRAID/perccli/perccli64"
+            "path": "/opt/MegaRAID/perccli/perccli64",
+            "deleteAll": true
         }
     },
     "tasks": [
@@ -33,10 +38,11 @@
             "label": "delete-raid",
             "taskName": "Task.Raid.Delete.MegaRAID",
             "waitOn": {
-                "bootstrap-ubuntu": "succeeded"
+                "reboot": "succeeded"
             }
         },
         {
+            "ignoreFailure": true,
             "label": "refresh-catalog-megaraid",
             "taskName": "Task.Catalog.perccli",
             "waitOn": {
@@ -44,10 +50,24 @@
             }
         },
         {
+            "label": "refresh-catalog-driveid",
+            "taskName": "Task.Catalog.Drive.Id",
+            "waitOn": {
+                "refresh-catalog-megaraid": "succeeded"
+            }
+        },
+        {
+            "label": "finish-bootstrap-trigger",
+            "taskName": "Task.Trigger.Send.Finish",
+            "waitOn": {
+                "final-reboot": "finished"
+            }
+        },
+        {
             "label": "final-reboot",
             "taskName": "Task.Obm.Node.Reboot",
             "waitOn": {
-                "refresh-catalog-megaraid": "finished"
+                "refresh-catalog-driveid": "succeeded"
             }
         }
     ]

--- a/dell-c6320/workflows/dell-perccli-delete-megaraid-graph.json
+++ b/dell-c6320/workflows/dell-perccli-delete-megaraid-graph.json
@@ -57,17 +57,17 @@
             }
         },
         {
-            "label": "finish-bootstrap-trigger",
-            "taskName": "Task.Trigger.Send.Finish",
-            "waitOn": {
-                "final-reboot": "finished"
-            }
-        },
-        {
             "label": "final-reboot",
             "taskName": "Task.Obm.Node.Reboot",
             "waitOn": {
                 "refresh-catalog-driveid": "succeeded"
+            }
+        },
+        {
+            "label": "finish-bootstrap-trigger",
+            "taskName": "Task.Trigger.Send.Finish",
+            "waitOn": {
+                "final-reboot": "finished"
             }
         }
     ]

--- a/dell-r630/workflows/dell-perccli-create-megaraid-graph.json
+++ b/dell-r630/workflows/dell-perccli-create-megaraid-graph.json
@@ -1,4 +1,3 @@
-root@kcps-rackhd01:/home/wangzz/on-skupack/dell-r730/workflows# cat dell-perccli-create-megaraid-graph.json
 {
     "friendlyName": "Create RAID via perccli",
     "injectableName": "Graph.Raid.Create.Perccli",

--- a/dell-r630/workflows/dell-perccli-create-megaraid-graph.json
+++ b/dell-r630/workflows/dell-perccli-create-megaraid-graph.json
@@ -1,12 +1,18 @@
+root@kcps-rackhd01:/home/wangzz/on-skupack/dell-r730/workflows# cat dell-perccli-create-megaraid-graph.json
 {
     "friendlyName": "Create RAID via perccli",
     "injectableName": "Graph.Raid.Create.Perccli",
     "options": {
         "bootstrap-ubuntu": {
-            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz"
+            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz",
+            "triggerGroup": "bootstrap"
+        },
+        "finish-bootstrap-trigger":{
+            "triggerGroup": "bootstrap"
         },
         "create-raid": {
-            "path": "/opt/MegaRAID/perccli/perccli64"
+            "path": "/opt/MegaRAID/perccli/perccli64",
+            "createDefault": true
         }
     },
     "tasks": [
@@ -33,7 +39,7 @@
             "label": "create-raid",
             "taskName": "Task.Raid.Create.MegaRAID",
             "waitOn": {
-                "bootstrap-ubuntu": "succeeded"
+                "reboot": "succeeded"
             }
         },
         {
@@ -44,10 +50,24 @@
             }
         },
         {
+            "label": "refresh-catalog-driveid",
+            "taskName": "Task.Catalog.Drive.Id",
+            "waitOn": {
+                "refresh-catalog-megaraid": "succeeded"
+            }
+        },
+        {
+            "label": "finish-bootstrap-trigger",
+            "taskName": "Task.Trigger.Send.Finish",
+            "waitOn": {
+                "final-reboot": "finished"
+            }
+        },
+        {
             "label": "final-reboot",
             "taskName": "Task.Obm.Node.Reboot",
             "waitOn": {
-                "refresh-catalog-megaraid": "finished"
+                "refresh-catalog-driveid": "succeeded"
             }
         }
     ]

--- a/dell-r630/workflows/dell-perccli-create-megaraid-graph.json
+++ b/dell-r630/workflows/dell-perccli-create-megaraid-graph.json
@@ -57,17 +57,17 @@ root@kcps-rackhd01:/home/wangzz/on-skupack/dell-r730/workflows# cat dell-perccli
             }
         },
         {
-            "label": "finish-bootstrap-trigger",
-            "taskName": "Task.Trigger.Send.Finish",
-            "waitOn": {
-                "final-reboot": "finished"
-            }
-        },
-        {
             "label": "final-reboot",
             "taskName": "Task.Obm.Node.Reboot",
             "waitOn": {
                 "refresh-catalog-driveid": "succeeded"
+            }
+        },
+        {
+            "label": "finish-bootstrap-trigger",
+            "taskName": "Task.Trigger.Send.Finish",
+            "waitOn": {
+                "final-reboot": "finished"
             }
         }
     ]

--- a/dell-r630/workflows/dell-perccli-delete-megaraid-graph.json
+++ b/dell-r630/workflows/dell-perccli-delete-megaraid-graph.json
@@ -3,10 +3,15 @@
     "injectableName": "Graph.Raid.Delete.Perccli",
     "options": {
         "bootstrap-ubuntu": {
-            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz"
+            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz",
+            "triggerGroup": "bootstrap"
+        },
+        "finish-bootstrap-trigger": {
+            "triggerGroup": "bootstrap"
         },
         "delete-raid": {
-            "path": "/opt/MegaRAID/perccli/perccli64"
+            "path": "/opt/MegaRAID/perccli/perccli64",
+            "deleteAll": true
         }
     },
     "tasks": [
@@ -33,10 +38,11 @@
             "label": "delete-raid",
             "taskName": "Task.Raid.Delete.MegaRAID",
             "waitOn": {
-                "bootstrap-ubuntu": "succeeded"
+                "reboot": "succeeded"
             }
         },
         {
+            "ignoreFailure": true,
             "label": "refresh-catalog-megaraid",
             "taskName": "Task.Catalog.perccli",
             "waitOn": {
@@ -44,10 +50,24 @@
             }
         },
         {
+            "label": "refresh-catalog-driveid",
+            "taskName": "Task.Catalog.Drive.Id",
+            "waitOn": {
+                "refresh-catalog-megaraid": "succeeded"
+            }
+        },
+        {
+            "label": "finish-bootstrap-trigger",
+            "taskName": "Task.Trigger.Send.Finish",
+            "waitOn": {
+                "final-reboot": "finished"
+            }
+        },
+        {
             "label": "final-reboot",
             "taskName": "Task.Obm.Node.Reboot",
             "waitOn": {
-                "refresh-catalog-megaraid": "finished"
+                "refresh-catalog-driveid": "succeeded"
             }
         }
     ]

--- a/dell-r630/workflows/dell-perccli-delete-megaraid-graph.json
+++ b/dell-r630/workflows/dell-perccli-delete-megaraid-graph.json
@@ -57,17 +57,17 @@
             }
         },
         {
-            "label": "finish-bootstrap-trigger",
-            "taskName": "Task.Trigger.Send.Finish",
-            "waitOn": {
-                "final-reboot": "finished"
-            }
-        },
-        {
             "label": "final-reboot",
             "taskName": "Task.Obm.Node.Reboot",
             "waitOn": {
                 "refresh-catalog-driveid": "succeeded"
+            }
+        },
+        {
+            "label": "finish-bootstrap-trigger",
+            "taskName": "Task.Trigger.Send.Finish",
+            "waitOn": {
+                "final-reboot": "finished"
             }
         }
     ]

--- a/dell-r730/workflows/dell-perccli-create-megaraid-graph.json
+++ b/dell-r730/workflows/dell-perccli-create-megaraid-graph.json
@@ -1,4 +1,3 @@
-root@kcps-rackhd01:/home/wangzz/on-skupack/dell-r730/workflows# cat dell-perccli-create-megaraid-graph.json
 {
     "friendlyName": "Create RAID via perccli",
     "injectableName": "Graph.Raid.Create.Perccli",

--- a/dell-r730/workflows/dell-perccli-create-megaraid-graph.json
+++ b/dell-r730/workflows/dell-perccli-create-megaraid-graph.json
@@ -1,12 +1,33 @@
+root@kcps-rackhd01:/home/wangzz/on-skupack/dell-r730/workflows# cat dell-perccli-create-megaraid-graph.json
 {
     "friendlyName": "Create RAID via perccli",
     "injectableName": "Graph.Raid.Create.Perccli",
     "options": {
         "bootstrap-ubuntu": {
-            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz"
+            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz",
+            "triggerGroup": "bootstrap"
+        },
+        "finish-bootstrap-trigger":{
+            "triggerGroup": "bootstrap"
         },
         "create-raid": {
-            "path": "/opt/MegaRAID/perccli/perccli64"
+            "path": "/opt/MegaRAID/perccli/perccli64",
+            "createDefault": true,
+            "raidList":
+            [
+              {
+                "enclosure": 32,
+                "type": "raid0",
+                "drives": [0],
+                "name": "vd1"
+              },
+              {
+                "enclosure": 32,
+                "type": "raid0",
+                "drives": [1],
+                "name": "vd2"
+              }
+            ]
         }
     },
     "tasks": [
@@ -33,7 +54,7 @@
             "label": "create-raid",
             "taskName": "Task.Raid.Create.MegaRAID",
             "waitOn": {
-                "bootstrap-ubuntu": "succeeded"
+                "reboot": "succeeded"
             }
         },
         {
@@ -44,10 +65,24 @@
             }
         },
         {
+            "label": "refresh-catalog-driveid",
+            "taskName": "Task.Catalog.Drive.Id",
+            "waitOn": {
+                "refresh-catalog-megaraid": "succeeded"
+            }
+        },
+        {
+            "label": "finish-bootstrap-trigger",
+            "taskName": "Task.Trigger.Send.Finish",
+            "waitOn": {
+                "final-reboot": "finished"
+            }
+        },
+        {
             "label": "final-reboot",
             "taskName": "Task.Obm.Node.Reboot",
             "waitOn": {
-                "refresh-catalog-megaraid": "finished"
+                "refresh-catalog-driveid": "succeeded"
             }
         }
     ]

--- a/dell-r730/workflows/dell-perccli-create-megaraid-graph.json
+++ b/dell-r730/workflows/dell-perccli-create-megaraid-graph.json
@@ -12,22 +12,7 @@ root@kcps-rackhd01:/home/wangzz/on-skupack/dell-r730/workflows# cat dell-perccli
         },
         "create-raid": {
             "path": "/opt/MegaRAID/perccli/perccli64",
-            "createDefault": true,
-            "raidList":
-            [
-              {
-                "enclosure": 32,
-                "type": "raid0",
-                "drives": [0],
-                "name": "vd1"
-              },
-              {
-                "enclosure": 32,
-                "type": "raid0",
-                "drives": [1],
-                "name": "vd2"
-              }
-            ]
+            "createDefault": true
         }
     },
     "tasks": [

--- a/dell-r730/workflows/dell-perccli-create-megaraid-graph.json
+++ b/dell-r730/workflows/dell-perccli-create-megaraid-graph.json
@@ -57,17 +57,17 @@ root@kcps-rackhd01:/home/wangzz/on-skupack/dell-r730/workflows# cat dell-perccli
             }
         },
         {
-            "label": "finish-bootstrap-trigger",
-            "taskName": "Task.Trigger.Send.Finish",
-            "waitOn": {
-                "final-reboot": "finished"
-            }
-        },
-        {
             "label": "final-reboot",
             "taskName": "Task.Obm.Node.Reboot",
             "waitOn": {
                 "refresh-catalog-driveid": "succeeded"
+            }
+        },
+        {
+            "label": "finish-bootstrap-trigger",
+            "taskName": "Task.Trigger.Send.Finish",
+            "waitOn": {
+                "final-reboot": "finished"
             }
         }
     ]

--- a/dell-r730/workflows/dell-perccli-delete-megaraid-graph.json
+++ b/dell-r730/workflows/dell-perccli-delete-megaraid-graph.json
@@ -3,10 +3,16 @@
     "injectableName": "Graph.Raid.Delete.Perccli",
     "options": {
         "bootstrap-ubuntu": {
-            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz"
+            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz",
+            "triggerGroup": "bootstrap"
+        },
+        "finish-bootstrap-trigger": {
+            "triggerGroup": "bootstrap"
         },
         "delete-raid": {
-            "path": "/opt/MegaRAID/perccli/perccli64"
+            "path": "/opt/MegaRAID/perccli/perccli64",
+            "deleteAll": true,
+            "raidIds": [0]
         }
     },
     "tasks": [
@@ -33,10 +39,11 @@
             "label": "delete-raid",
             "taskName": "Task.Raid.Delete.MegaRAID",
             "waitOn": {
-                "bootstrap-ubuntu": "succeeded"
+                "reboot": "succeeded"
             }
         },
         {
+            "ignoreFailure": true,
             "label": "refresh-catalog-megaraid",
             "taskName": "Task.Catalog.perccli",
             "waitOn": {
@@ -44,10 +51,24 @@
             }
         },
         {
+            "label": "refresh-catalog-driveid",
+            "taskName": "Task.Catalog.Drive.Id",
+            "waitOn": {
+                "refresh-catalog-megaraid": "succeeded"
+            }
+        },
+        {
+            "label": "finish-bootstrap-trigger",
+            "taskName": "Task.Trigger.Send.Finish",
+            "waitOn": {
+                "final-reboot": "finished"
+            }
+        },
+        {
             "label": "final-reboot",
             "taskName": "Task.Obm.Node.Reboot",
             "waitOn": {
-                "refresh-catalog-megaraid": "finished"
+                "refresh-catalog-driveid": "succeeded"
             }
         }
     ]

--- a/dell-r730/workflows/dell-perccli-delete-megaraid-graph.json
+++ b/dell-r730/workflows/dell-perccli-delete-megaraid-graph.json
@@ -11,8 +11,7 @@
         },
         "delete-raid": {
             "path": "/opt/MegaRAID/perccli/perccli64",
-            "deleteAll": true,
-            "raidIds": [0]
+            "deleteAll": true
         }
     },
     "tasks": [

--- a/dell-r730/workflows/dell-perccli-delete-megaraid-graph.json
+++ b/dell-r730/workflows/dell-perccli-delete-megaraid-graph.json
@@ -57,17 +57,17 @@
             }
         },
         {
-            "label": "finish-bootstrap-trigger",
-            "taskName": "Task.Trigger.Send.Finish",
-            "waitOn": {
-                "final-reboot": "finished"
-            }
-        },
-        {
             "label": "final-reboot",
             "taskName": "Task.Obm.Node.Reboot",
             "waitOn": {
                 "refresh-catalog-driveid": "succeeded"
+            }
+        },
+        {
+            "label": "finish-bootstrap-trigger",
+            "taskName": "Task.Trigger.Send.Finish",
+            "waitOn": {
+                "final-reboot": "finished"
             }
         }
     ]

--- a/dell-r730xd/workflows/dell-perccli-create-megaraid-graph.json
+++ b/dell-r730xd/workflows/dell-perccli-create-megaraid-graph.json
@@ -1,4 +1,3 @@
-root@kcps-rackhd01:/home/wangzz/on-skupack/dell-r730/workflows# cat dell-perccli-create-megaraid-graph.json
 {
     "friendlyName": "Create RAID via perccli",
     "injectableName": "Graph.Raid.Create.Perccli",

--- a/dell-r730xd/workflows/dell-perccli-create-megaraid-graph.json
+++ b/dell-r730xd/workflows/dell-perccli-create-megaraid-graph.json
@@ -1,12 +1,18 @@
+root@kcps-rackhd01:/home/wangzz/on-skupack/dell-r730/workflows# cat dell-perccli-create-megaraid-graph.json
 {
     "friendlyName": "Create RAID via perccli",
     "injectableName": "Graph.Raid.Create.Perccli",
     "options": {
         "bootstrap-ubuntu": {
-            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz"
+            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz",
+            "triggerGroup": "bootstrap"
+        },
+        "finish-bootstrap-trigger":{
+            "triggerGroup": "bootstrap"
         },
         "create-raid": {
-            "path": "/opt/MegaRAID/perccli/perccli64"
+            "path": "/opt/MegaRAID/perccli/perccli64",
+            "createDefault": true
         }
     },
     "tasks": [
@@ -33,7 +39,7 @@
             "label": "create-raid",
             "taskName": "Task.Raid.Create.MegaRAID",
             "waitOn": {
-                "bootstrap-ubuntu": "succeeded"
+                "reboot": "succeeded"
             }
         },
         {
@@ -44,10 +50,24 @@
             }
         },
         {
+            "label": "refresh-catalog-driveid",
+            "taskName": "Task.Catalog.Drive.Id",
+            "waitOn": {
+                "refresh-catalog-megaraid": "succeeded"
+            }
+        },
+        {
+            "label": "finish-bootstrap-trigger",
+            "taskName": "Task.Trigger.Send.Finish",
+            "waitOn": {
+                "final-reboot": "finished"
+            }
+        },
+        {
             "label": "final-reboot",
             "taskName": "Task.Obm.Node.Reboot",
             "waitOn": {
-                "refresh-catalog-megaraid": "finished"
+                "refresh-catalog-driveid": "succeeded"
             }
         }
     ]

--- a/dell-r730xd/workflows/dell-perccli-create-megaraid-graph.json
+++ b/dell-r730xd/workflows/dell-perccli-create-megaraid-graph.json
@@ -57,17 +57,17 @@ root@kcps-rackhd01:/home/wangzz/on-skupack/dell-r730/workflows# cat dell-perccli
             }
         },
         {
-            "label": "finish-bootstrap-trigger",
-            "taskName": "Task.Trigger.Send.Finish",
-            "waitOn": {
-                "final-reboot": "finished"
-            }
-        },
-        {
             "label": "final-reboot",
             "taskName": "Task.Obm.Node.Reboot",
             "waitOn": {
                 "refresh-catalog-driveid": "succeeded"
+            }
+        },
+        {
+            "label": "finish-bootstrap-trigger",
+            "taskName": "Task.Trigger.Send.Finish",
+            "waitOn": {
+                "final-reboot": "finished"
             }
         }
     ]

--- a/dell-r730xd/workflows/dell-perccli-delete-megaraid-graph.json
+++ b/dell-r730xd/workflows/dell-perccli-delete-megaraid-graph.json
@@ -3,10 +3,15 @@
     "injectableName": "Graph.Raid.Delete.Perccli",
     "options": {
         "bootstrap-ubuntu": {
-            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz"
+            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz",
+            "triggerGroup": "bootstrap"
+        },
+        "finish-bootstrap-trigger": {
+            "triggerGroup": "bootstrap"
         },
         "delete-raid": {
-            "path": "/opt/MegaRAID/perccli/perccli64"
+            "path": "/opt/MegaRAID/perccli/perccli64",
+            "deleteAll": true
         }
     },
     "tasks": [
@@ -33,10 +38,11 @@
             "label": "delete-raid",
             "taskName": "Task.Raid.Delete.MegaRAID",
             "waitOn": {
-                "bootstrap-ubuntu": "succeeded"
+                "reboot": "succeeded"
             }
         },
         {
+            "ignoreFailure": true,
             "label": "refresh-catalog-megaraid",
             "taskName": "Task.Catalog.perccli",
             "waitOn": {
@@ -44,10 +50,24 @@
             }
         },
         {
+            "label": "refresh-catalog-driveid",
+            "taskName": "Task.Catalog.Drive.Id",
+            "waitOn": {
+                "refresh-catalog-megaraid": "succeeded"
+            }
+        },
+        {
+            "label": "finish-bootstrap-trigger",
+            "taskName": "Task.Trigger.Send.Finish",
+            "waitOn": {
+                "final-reboot": "finished"
+            }
+        },
+        {
             "label": "final-reboot",
             "taskName": "Task.Obm.Node.Reboot",
             "waitOn": {
-                "refresh-catalog-megaraid": "finished"
+                "refresh-catalog-driveid": "succeeded"
             }
         }
     ]

--- a/dell-r730xd/workflows/dell-perccli-delete-megaraid-graph.json
+++ b/dell-r730xd/workflows/dell-perccli-delete-megaraid-graph.json
@@ -57,17 +57,17 @@
             }
         },
         {
-            "label": "finish-bootstrap-trigger",
-            "taskName": "Task.Trigger.Send.Finish",
-            "waitOn": {
-                "final-reboot": "finished"
-            }
-        },
-        {
             "label": "final-reboot",
             "taskName": "Task.Obm.Node.Reboot",
             "waitOn": {
                 "refresh-catalog-driveid": "succeeded"
+            }
+        },
+        {
+            "label": "finish-bootstrap-trigger",
+            "taskName": "Task.Trigger.Send.Finish",
+            "waitOn": {
+                "final-reboot": "finished"
             }
         }
     ]


### PR DESCRIPTION
In these two workflows, we could deleted/created virtual disk, so it is necessary to refresh the catalog source driveid is vd changed. added trigger group and Task.Catalog.Drive.Id to update driveid