### PR TITLE
RAC-5972 Remove unnecessary optionsSchema section

### DIFF
--- a/quanta-d51-2u/workflows/flash-quanta-bios-graph.json
+++ b/quanta-d51-2u/workflows/flash-quanta-bios-graph.json
@@ -34,7 +34,6 @@
           "friendlyName": "Upgrade firmware images",
           "injectableName": "Task.Linux.Command.Upgrade.BIOS",
           "implementsTask": "Task.Base.Linux.Commands",
-          "optionsSchema": "sku-firmware-update.json",
           "options": {
             "commands": [
               {

--- a/quanta-d51-2u/workflows/flash-quanta-bmc-graph.json
+++ b/quanta-d51-2u/workflows/flash-quanta-bmc-graph.json
@@ -44,7 +44,6 @@
           "friendlyName": "Upgrade firmware images",
           "injectableName": "Task.Linux.Command.Upgrade.Bmc",
           "implementsTask": "Task.Base.Linux.Commands",
-          "optionsSchema": "sku-firmware-update.json",
           "options": {
             "commands": [
               {

--- a/quanta-t41/workflows/flash-quanta-bios-graph.json
+++ b/quanta-t41/workflows/flash-quanta-bios-graph.json
@@ -34,7 +34,6 @@
           "friendlyName": "Upgrade firmware images",
           "injectableName": "Task.Linux.Command.Upgrade.BIOS",
           "implementsTask": "Task.Base.Linux.Commands",
-          "optionsSchema": "sku-firmware-update.json",
           "options": {
             "commands": [
               {

--- a/quanta-t41/workflows/flash-quanta-bmc-graph.json
+++ b/quanta-t41/workflows/flash-quanta-bmc-graph.json
@@ -44,7 +44,6 @@
           "friendlyName": "Upgrade firmware images",
           "injectableName": "Task.Linux.Command.Upgrade.Bmc",
           "implementsTask": "Task.Base.Linux.Commands",
-          "optionsSchema": "sku-firmware-update.json",
           "options": {
             "commands": [
               {


### PR DESCRIPTION
## Background
The in the Quanta server bios/bmc update workflow, there is a optionSchema field.  It intended to reference  sku-firmware-update.json to do input option schema validation. However this sku-firmware-update.json is only valid for Dell server firmware update flow. On other servers, this unnecessary field will bring out issue. It requires a non-existed  "file" option. Thus make the workflow unable to start.

## Details
Remove all the optionSchema field in those skupacks.

## Test Result
Tested pass on Physical Quanta T41 node.

@iceiilin @pengz1 