### PR TITLE
replace bootstrap-ubuntu with bootstrap-rancher

### DIFF
--- a/dell-c6320/workflows/dell-discovery-graph.json
+++ b/dell-c6320/workflows/dell-discovery-graph.json
@@ -2,20 +2,20 @@
     "friendlyName": "Dell Discovery",
     "injectableName": "Graph.Dell.Discovery",
     "options": {
-        "bootstrap-ubuntu": {
-            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz"
+        "bootstrap-rancher": {
+            "dockerFile": "dell.raid.docker.tar.xz"
         }
     },
     "tasks": [
         {
-            "label": "bootstrap-ubuntu",
-            "taskName": "Task.Linux.Bootstrap.Ubuntu"
+            "label": "bootstrap-rancher",
+            "taskName": "Task.Linux.Bootstrap.Rancher"
         },
         {
             "label": "catalog-perccli",
             "taskName": "Task.Catalog.perccli",
             "waitOn": {
-                "bootstrap-ubuntu": "succeeded"
+                "bootstrap-rancher": "succeeded"
             }
         },
         {

--- a/dell-c6320/workflows/dell-perccli-create-megaraid-graph.json
+++ b/dell-c6320/workflows/dell-perccli-create-megaraid-graph.json
@@ -2,8 +2,8 @@
     "friendlyName": "Create RAID via perccli",
     "injectableName": "Graph.Raid.Create.Perccli",
     "options": {
-        "bootstrap-ubuntu": {
-            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz",
+        "bootstrap-rancher": {
+            "dockerFile": "dell.raid.docker.tar.xz",
             "triggerGroup": "bootstrap"
         },
         "finish-bootstrap-trigger":{
@@ -28,8 +28,8 @@
             }
         },
         {
-            "label": "bootstrap-ubuntu",
-            "taskName": "Task.Linux.Bootstrap.Ubuntu",
+            "label": "bootstrap-rancher",
+            "taskName": "Task.Linux.Bootstrap.Rancher",
             "waitOn": {
                 "reboot": "succeeded"
             }

--- a/dell-c6320/workflows/dell-perccli-delete-megaraid-graph.json
+++ b/dell-c6320/workflows/dell-perccli-delete-megaraid-graph.json
@@ -2,8 +2,8 @@
     "friendlyName": "Delete RAID via Perccli",
     "injectableName": "Graph.Raid.Delete.Perccli",
     "options": {
-        "bootstrap-ubuntu": {
-            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz",
+        "bootstrap-rancher": {
+            "dockerFile": "dell.raid.docker.tar.xz",
             "triggerGroup": "bootstrap"
         },
         "finish-bootstrap-trigger": {
@@ -28,8 +28,8 @@
             }
         },
         {
-            "label": "bootstrap-ubuntu",
-            "taskName": "Task.Linux.Bootstrap.Ubuntu",
+            "label": "bootstrap-rancher",
+            "taskName": "Task.Linux.Bootstrap.Rancher",
             "waitOn": {
                 "reboot": "succeeded"
             }

--- a/dell-c6320/workflows/dell-perccli-megaraid-catalog.json
+++ b/dell-c6320/workflows/dell-perccli-megaraid-catalog.json
@@ -2,8 +2,8 @@
     "friendlyName": "Dell perccli Catalog",
     "injectableName": "Graph.Dell.perccli.Catalog",
     "options": {
-        "bootstrap-ubuntu": {
-            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz"
+        "bootstrap-rancher": {
+            "dockerFile": "dell.raid.docker.tar.xz"
         }
     },
     "tasks": [
@@ -20,8 +20,8 @@
             }
         },
         {
-            "label": "bootstrap-ubuntu",
-            "taskName": "Task.Linux.Bootstrap.Ubuntu",
+            "label": "bootstrap-rancher",
+            "taskName": "Task.Linux.Bootstrap.Rancher",
             "waitOn": {
                 "reboot-start": "succeeded"
             }
@@ -31,7 +31,7 @@
             "label": "catalog-perccli",
             "taskName": "Task.Catalog.perccli",
             "waitOn": {
-                "bootstrap-ubuntu": "succeeded"
+                "bootstrap-rancher": "succeeded"
             }
         },
         {

--- a/dell-c6320/workflows/dell-secure-erase-drive-graph.json
+++ b/dell-c6320/workflows/dell-secure-erase-drive-graph.json
@@ -2,8 +2,8 @@
     "friendlyName": "Secure Erase Drive",
     "injectableName": "Graph.Drive.SecureErase",
     "options": {
-        "bootstrap-ubuntu": {
-            "overlayfsFile": "secure.erase.overlay.cpio.gz",
+        "bootstrap-rancher": {
+            "dockerFile": "secure.erase.docker.tar.xz",
             "triggerGroup": "secureErase"
         },
         "drive-scan-delay": {
@@ -37,8 +37,8 @@
             }
         },
         {
-            "label": "bootstrap-ubuntu",
-            "taskName": "Task.Linux.Bootstrap.Ubuntu",
+            "label": "bootstrap-rancher",
+            "taskName": "Task.Linux.Bootstrap.Rancher",
             "waitOn": {
                 "reboot": "succeeded"
             }

--- a/dell-r630/workflows/dell-discovery-graph.json
+++ b/dell-r630/workflows/dell-discovery-graph.json
@@ -2,20 +2,20 @@
     "friendlyName": "Dell Discovery",
     "injectableName": "Graph.Dell.Discovery",
     "options": {
-        "bootstrap-ubuntu": {
-            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz"
+        "bootstrap-rancher": {
+            "dockerFile": "dell.raid.docker.tar.xz"
         }
     },
     "tasks": [
         {
-            "label": "bootstrap-ubuntu",
-            "taskName": "Task.Linux.Bootstrap.Ubuntu"
+            "label": "bootstrap-rancher",
+            "taskName": "Task.Linux.Bootstrap.Rancher"
         },
         {
             "label": "catalog-perccli",
             "taskName": "Task.Catalog.perccli",
             "waitOn": {
-                "bootstrap-ubuntu": "succeeded"
+                "bootstrap-rancher": "succeeded"
             }
         },
         {

--- a/dell-r630/workflows/dell-perccli-create-megaraid-graph.json
+++ b/dell-r630/workflows/dell-perccli-create-megaraid-graph.json
@@ -2,8 +2,8 @@
     "friendlyName": "Create RAID via perccli",
     "injectableName": "Graph.Raid.Create.Perccli",
     "options": {
-        "bootstrap-ubuntu": {
-            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz",
+        "bootstrap-rancher": {
+            "dockerFile": "dell.raid.docker.tar.xz",
             "triggerGroup": "bootstrap"
         },
         "finish-bootstrap-trigger":{
@@ -28,8 +28,8 @@
             }
         },
         {
-            "label": "bootstrap-ubuntu",
-            "taskName": "Task.Linux.Bootstrap.Ubuntu",
+            "label": "bootstrap-rancher",
+            "taskName": "Task.Linux.Bootstrap.Rancher",
             "waitOn": {
                 "reboot": "succeeded"
             }

--- a/dell-r630/workflows/dell-perccli-delete-megaraid-graph.json
+++ b/dell-r630/workflows/dell-perccli-delete-megaraid-graph.json
@@ -2,8 +2,8 @@
     "friendlyName": "Delete RAID via Perccli",
     "injectableName": "Graph.Raid.Delete.Perccli",
     "options": {
-        "bootstrap-ubuntu": {
-            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz",
+        "bootstrap-rancher": {
+            "dockerFile": "dell.raid.docker.tar.xz",
             "triggerGroup": "bootstrap"
         },
         "finish-bootstrap-trigger": {
@@ -28,8 +28,8 @@
             }
         },
         {
-            "label": "bootstrap-ubuntu",
-            "taskName": "Task.Linux.Bootstrap.Ubuntu",
+            "label": "bootstrap-rancher",
+            "taskName": "Task.Linux.Bootstrap.Rancher",
             "waitOn": {
                 "reboot": "succeeded"
             }

--- a/dell-r630/workflows/dell-perccli-megaraid-catalog.json
+++ b/dell-r630/workflows/dell-perccli-megaraid-catalog.json
@@ -2,8 +2,8 @@
     "friendlyName": "Dell perccli Catalog",
     "injectableName": "Graph.Dell.perccli.Catalog",
     "options": {
-        "bootstrap-ubuntu": {
-            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz"
+        "bootstrap-rancher": {
+            "dockerFile": "dell.raid.docker.tar.xz"
         }
     },
     "tasks": [
@@ -20,8 +20,8 @@
             }
         },
         {
-            "label": "bootstrap-ubuntu",
-            "taskName": "Task.Linux.Bootstrap.Ubuntu",
+            "label": "bootstrap-rancher",
+            "taskName": "Task.Linux.Bootstrap.Rancher",
             "waitOn": {
                 "reboot-start": "succeeded"
             }
@@ -31,7 +31,7 @@
             "label": "catalog-perccli",
             "taskName": "Task.Catalog.perccli",
             "waitOn": {
-                "bootstrap-ubuntu": "succeeded"
+                "bootstrap-rancher": "succeeded"
             }
         },
         {

--- a/dell-r630/workflows/dell-secure-erase-drive-graph.json
+++ b/dell-r630/workflows/dell-secure-erase-drive-graph.json
@@ -2,8 +2,8 @@
     "friendlyName": "Secure Erase Drive",
     "injectableName": "Graph.Drive.SecureErase",
     "options": {
-        "bootstrap-ubuntu": {
-            "overlayfsFile": "secure.erase.overlay.cpio.gz",
+        "bootstrap-rancher": {
+            "dockerFile": "secure.erase.docker.tar.xz",
             "triggerGroup": "secureErase"
         },
         "drive-scan-delay": {
@@ -37,8 +37,8 @@
             }
         },
         {
-            "label": "bootstrap-ubuntu",
-            "taskName": "Task.Linux.Bootstrap.Ubuntu",
+            "label": "bootstrap-rancher",
+            "taskName": "Task.Linux.Bootstrap.Rancher",
             "waitOn": {
                 "reboot": "succeeded"
             }

--- a/dell-r640/workflows/dell-discovery-graph.json
+++ b/dell-r640/workflows/dell-discovery-graph.json
@@ -2,20 +2,20 @@
     "friendlyName": "Dell Discovery",
     "injectableName": "Graph.Dell.Discovery",
     "options": {
-        "bootstrap-ubuntu": {
-            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz"
+        "bootstrap-rancher": {
+            "dockerFile": "dell.raid.docker.tar.xz"
         }
     },
     "tasks": [
         {
-            "label": "bootstrap-ubuntu",
-            "taskName": "Task.Linux.Bootstrap.Ubuntu"
+            "label": "bootstrap-rancher",
+            "taskName": "Task.Linux.Bootstrap.Rancher"
         },
         {
             "label": "catalog-perccli",
             "taskName": "Task.Catalog.perccli",
             "waitOn": {
-                "bootstrap-ubuntu": "succeeded"
+                "bootstrap-rancher": "succeeded"
             }
         },
         {

--- a/dell-r640/workflows/dell-secure-erase-drive-graph.json
+++ b/dell-r640/workflows/dell-secure-erase-drive-graph.json
@@ -2,8 +2,8 @@
     "friendlyName": "Secure Erase Drive",
     "injectableName": "Graph.Drive.SecureErase",
     "options": {
-        "bootstrap-ubuntu": {
-            "overlayfsFile": "secure.erase.overlay.cpio.gz",
+        "bootstrap-rancher": {
+            "dockerFile": "secure.erase.docker.tar.xz",
             "triggerGroup": "secureErase"
         },
         "drive-scan-delay": {
@@ -37,8 +37,8 @@
             }
         },
         {
-            "label": "bootstrap-ubuntu",
-            "taskName": "Task.Linux.Bootstrap.Ubuntu",
+            "label": "bootstrap-rancher",
+            "taskName": "Task.Linux.Bootstrap.Rancher",
             "waitOn": {
                 "reboot": "succeeded"
             }

--- a/dell-r730/workflows/dell-discovery-graph.json
+++ b/dell-r730/workflows/dell-discovery-graph.json
@@ -2,20 +2,20 @@
     "friendlyName": "Dell Discovery",
     "injectableName": "Graph.Dell.Discovery",
     "options": {
-        "bootstrap-ubuntu": {
-            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz"
+        "bootstrap-rancher": {
+            "dockerFile": "dell.raid.docker.tar.xz"
         }
     },
     "tasks": [
         {
-            "label": "bootstrap-ubuntu",
-            "taskName": "Task.Linux.Bootstrap.Ubuntu"
+            "label": "bootstrap-rancher",
+            "taskName": "Task.Linux.Bootstrap.Rancher"
         },
         {
             "label": "catalog-perccli",
             "taskName": "Task.Catalog.perccli",
             "waitOn": {
-                "bootstrap-ubuntu": "succeeded"
+                "bootstrap-rancher": "succeeded"
             }
         },
         {

--- a/dell-r730/workflows/dell-perccli-create-megaraid-graph.json
+++ b/dell-r730/workflows/dell-perccli-create-megaraid-graph.json
@@ -2,8 +2,8 @@
     "friendlyName": "Create RAID via perccli",
     "injectableName": "Graph.Raid.Create.Perccli",
     "options": {
-        "bootstrap-ubuntu": {
-            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz",
+        "bootstrap-rancher": {
+            "dockerFile": "dell.raid.docker.tar.xz",
             "triggerGroup": "bootstrap"
         },
         "finish-bootstrap-trigger":{
@@ -28,8 +28,8 @@
             }
         },
         {
-            "label": "bootstrap-ubuntu",
-            "taskName": "Task.Linux.Bootstrap.Ubuntu",
+            "label": "bootstrap-rancher",
+            "taskName": "Task.Linux.Bootstrap.Rancher",
             "waitOn": {
                 "reboot": "succeeded"
             }

--- a/dell-r730/workflows/dell-perccli-delete-megaraid-graph.json
+++ b/dell-r730/workflows/dell-perccli-delete-megaraid-graph.json
@@ -2,8 +2,8 @@
     "friendlyName": "Delete RAID via Perccli",
     "injectableName": "Graph.Raid.Delete.Perccli",
     "options": {
-        "bootstrap-ubuntu": {
-            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz",
+        "bootstrap-rancher": {
+            "dockerFile": "dell.raid.docker.tar.xz",
             "triggerGroup": "bootstrap"
         },
         "finish-bootstrap-trigger": {
@@ -28,8 +28,8 @@
             }
         },
         {
-            "label": "bootstrap-ubuntu",
-            "taskName": "Task.Linux.Bootstrap.Ubuntu",
+            "label": "bootstrap-rancher",
+            "taskName": "Task.Linux.Bootstrap.Rancher",
             "waitOn": {
                 "reboot": "succeeded"
             }

--- a/dell-r730/workflows/dell-perccli-megaraid-catalog.json
+++ b/dell-r730/workflows/dell-perccli-megaraid-catalog.json
@@ -2,8 +2,8 @@
     "friendlyName": "Dell perccli Catalog",
     "injectableName": "Graph.Dell.perccli.Catalog",
     "options": {
-        "bootstrap-ubuntu": {
-            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz"
+        "bootstrap-rancher": {
+            "dockerFile": "dell.raid.docker.tar.xz"
         }
     },
     "tasks": [
@@ -20,8 +20,8 @@
             }
         },
         {
-            "label": "bootstrap-ubuntu",
-            "taskName": "Task.Linux.Bootstrap.Ubuntu",
+            "label": "bootstrap-rancher",
+            "taskName": "Task.Linux.Bootstrap.Rancher",
             "waitOn": {
                 "reboot-start": "succeeded"
             }
@@ -31,7 +31,7 @@
             "label": "catalog-perccli",
             "taskName": "Task.Catalog.perccli",
             "waitOn": {
-                "bootstrap-ubuntu": "succeeded"
+                "bootstrap-rancher": "succeeded"
             }
         },
         {

--- a/dell-r730/workflows/dell-secure-erase-drive-graph.json
+++ b/dell-r730/workflows/dell-secure-erase-drive-graph.json
@@ -2,8 +2,8 @@
     "friendlyName": "Secure Erase Drive",
     "injectableName": "Graph.Drive.SecureErase",
     "options": {
-        "bootstrap-ubuntu": {
-            "overlayfsFile": "secure.erase.overlay.cpio.gz",
+        "bootstrap-rancher": {
+            "dockerFile": "secure.erase.docker.tar.xz",
             "triggerGroup": "secureErase"
         },
         "drive-scan-delay": {
@@ -37,8 +37,8 @@
             }
         },
         {
-            "label": "bootstrap-ubuntu",
-            "taskName": "Task.Linux.Bootstrap.Ubuntu",
+            "label": "bootstrap-rancher",
+            "taskName": "Task.Linux.Bootstrap.Rancher",
             "waitOn": {
                 "reboot": "succeeded"
             }

--- a/dell-r730xd/workflows/dell-discovery-graph.json
+++ b/dell-r730xd/workflows/dell-discovery-graph.json
@@ -2,20 +2,20 @@
     "friendlyName": "Dell Discovery",
     "injectableName": "Graph.Dell.Discovery",
     "options": {
-        "bootstrap-ubuntu": {
-            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz"
+        "bootstrap-rancher": {
+            "dockerFile": "dell.raid.docker.tar.xz"
         }
     },
     "tasks": [
         {
-            "label": "bootstrap-ubuntu",
-            "taskName": "Task.Linux.Bootstrap.Ubuntu"
+            "label": "bootstrap-rancher",
+            "taskName": "Task.Linux.Bootstrap.Rancher"
         },
         {
             "label": "catalog-perccli",
             "taskName": "Task.Catalog.perccli",
             "waitOn": {
-                "bootstrap-ubuntu": "succeeded"
+                "bootstrap-rancher": "succeeded"
             }
         },
         {

--- a/dell-r730xd/workflows/dell-perccli-create-megaraid-graph.json
+++ b/dell-r730xd/workflows/dell-perccli-create-megaraid-graph.json
@@ -2,8 +2,8 @@
     "friendlyName": "Create RAID via perccli",
     "injectableName": "Graph.Raid.Create.Perccli",
     "options": {
-        "bootstrap-ubuntu": {
-            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz",
+        "bootstrap-rancher": {
+            "dockerFile": "dell.raid.docker.tar.xz",
             "triggerGroup": "bootstrap"
         },
         "finish-bootstrap-trigger":{
@@ -28,8 +28,8 @@
             }
         },
         {
-            "label": "bootstrap-ubuntu",
-            "taskName": "Task.Linux.Bootstrap.Ubuntu",
+            "label": "bootstrap-rancher",
+            "taskName": "Task.Linux.Bootstrap.Rancher",
             "waitOn": {
                 "reboot": "succeeded"
             }

--- a/dell-r730xd/workflows/dell-perccli-delete-megaraid-graph.json
+++ b/dell-r730xd/workflows/dell-perccli-delete-megaraid-graph.json
@@ -2,8 +2,8 @@
     "friendlyName": "Delete RAID via Perccli",
     "injectableName": "Graph.Raid.Delete.Perccli",
     "options": {
-        "bootstrap-ubuntu": {
-            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz",
+        "bootstrap-rancher": {
+            "dockerFile": "dell.raid.docker.tar.xz",
             "triggerGroup": "bootstrap"
         },
         "finish-bootstrap-trigger": {
@@ -28,8 +28,8 @@
             }
         },
         {
-            "label": "bootstrap-ubuntu",
-            "taskName": "Task.Linux.Bootstrap.Ubuntu",
+            "label": "bootstrap-rancher",
+            "taskName": "Task.Linux.Bootstrap.Rancher",
             "waitOn": {
                 "reboot": "succeeded"
             }

--- a/dell-r730xd/workflows/dell-perccli-megaraid-catalog.json
+++ b/dell-r730xd/workflows/dell-perccli-megaraid-catalog.json
@@ -2,8 +2,8 @@
     "friendlyName": "Dell perccli Catalog",
     "injectableName": "Graph.Dell.perccli.Catalog",
     "options": {
-        "bootstrap-ubuntu": {
-            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz"
+        "bootstrap-rancher": {
+            "dockerFile": "dell.raid.docker.tar.xz"
         }
     },
     "tasks": [
@@ -20,8 +20,8 @@
             }
         },
         {
-            "label": "bootstrap-ubuntu",
-            "taskName": "Task.Linux.Bootstrap.Ubuntu",
+            "label": "bootstrap-rancher",
+            "taskName": "Task.Linux.Bootstrap.Rancher",
             "waitOn": {
                 "reboot-start": "succeeded"
             }
@@ -31,7 +31,7 @@
             "label": "catalog-perccli",
             "taskName": "Task.Catalog.perccli",
             "waitOn": {
-                "bootstrap-ubuntu": "succeeded"
+                "bootstrap-rancher": "succeeded"
             }
         },
         {

--- a/dell-r730xd/workflows/dell-secure-erase-drive-graph.json
+++ b/dell-r730xd/workflows/dell-secure-erase-drive-graph.json
@@ -2,8 +2,8 @@
     "friendlyName": "Secure Erase Drive",
     "injectableName": "Graph.Drive.SecureErase",
     "options": {
-        "bootstrap-ubuntu": {
-            "overlayfsFile": "secure.erase.overlay.cpio.gz",
+        "bootstrap-rancher": {
+            "dockerFile": "secure.erase.docker.tar.xz",
             "triggerGroup": "secureErase"
         },
         "drive-scan-delay": {
@@ -37,8 +37,8 @@
             }
         },
         {
-            "label": "bootstrap-ubuntu",
-            "taskName": "Task.Linux.Bootstrap.Ubuntu",
+            "label": "bootstrap-rancher",
+            "taskName": "Task.Linux.Bootstrap.Rancher",
             "waitOn": {
                 "reboot": "succeeded"
             }

--- a/dell-r740/workflows/dell-discovery-graph.json
+++ b/dell-r740/workflows/dell-discovery-graph.json
@@ -2,20 +2,20 @@
     "friendlyName": "Dell Discovery",
     "injectableName": "Graph.Dell.Discovery",
     "options": {
-        "bootstrap-ubuntu": {
-            "overlayfsUri": "{{ api.server }}/common/dell.raid.overlay.cpio.gz"
+        "bootstrap-rancher": {
+            "dockerFile": "dell.raid.docker.tar.xz"
         }
     },
     "tasks": [
         {
-            "label": "bootstrap-ubuntu",
-            "taskName": "Task.Linux.Bootstrap.Ubuntu"
+            "label": "bootstrap-rancher",
+            "taskName": "Task.Linux.Bootstrap.Rancher"
         },
         {
             "label": "catalog-perccli",
             "taskName": "Task.Catalog.perccli",
             "waitOn": {
-                "bootstrap-ubuntu": "succeeded"
+                "bootstrap-rancher": "succeeded"
             }
         },
         {

--- a/dell-r740/workflows/dell-secure-erase-drive-graph.json
+++ b/dell-r740/workflows/dell-secure-erase-drive-graph.json
@@ -2,8 +2,8 @@
     "friendlyName": "Secure Erase Drive",
     "injectableName": "Graph.Drive.SecureErase",
     "options": {
-        "bootstrap-ubuntu": {
-            "overlayfsFile": "secure.erase.overlay.cpio.gz",
+        "bootstrap-rancher": {
+            "dockerFile": "secure.erase.docker.tar.xz",
             "triggerGroup": "secureErase"
         },
         "drive-scan-delay": {
@@ -37,8 +37,8 @@
             }
         },
         {
-            "label": "bootstrap-ubuntu",
-            "taskName": "Task.Linux.Bootstrap.Ubuntu",
+            "label": "bootstrap-rancher",
+            "taskName": "Task.Linux.Bootstrap.Rancher",
             "waitOn": {
                 "reboot": "succeeded"
             }

--- a/quanta-d51-2u/workflows/flash-quanta-bios-graph.json
+++ b/quanta-d51-2u/workflows/flash-quanta-bios-graph.json
@@ -21,8 +21,8 @@
         }
       },
       {
-        "label": "bootstrap-ubuntu",
-        "taskName": "Task.Linux.Bootstrap.Ubuntu",
+        "label": "bootstrap-rancher",
+        "taskName": "Task.Linux.Bootstrap.Rancher",
         "waitOn": {
           "reboot": "succeeded"
         }
@@ -45,7 +45,7 @@
           "properties": {}
         },
         "waitOn": {
-          "bootstrap-ubuntu": "succeeded"
+          "bootstrap-rancher": "succeeded"
         }
       },
       {

--- a/quanta-d51-2u/workflows/flash-quanta-bmc-graph.json
+++ b/quanta-d51-2u/workflows/flash-quanta-bmc-graph.json
@@ -24,8 +24,8 @@
       },
       {
         "x-description": "Configure the node to load the microkernel image",
-        "label": "bootstrap-ubuntu",
-        "taskName": "Task.Linux.Bootstrap.Ubuntu",
+        "label": "bootstrap-rancher",
+        "taskName": "Task.Linux.Bootstrap.Rancher",
         "waitOn": {
           "reboot": "succeeded"
         }
@@ -34,7 +34,7 @@
         "label": "catalog-quanta-bmc-before",
         "taskName": "Task.Catalog.bmc",
         "waitOn": {
-          "bootstrap-ubuntu": "succeeded"
+          "bootstrap-rancher": "succeeded"
         }
       },
       {

--- a/quanta-d51-2u/workflows/flash-quanta-megaraid-graph.json
+++ b/quanta-d51-2u/workflows/flash-quanta-megaraid-graph.json
@@ -15,8 +15,8 @@
         }
       },
       {
-        "label": "bootstrap-ubuntu",
-        "taskName": "Task.Linux.Bootstrap.Ubuntu",
+        "label": "bootstrap-rancher",
+        "taskName": "Task.Linux.Bootstrap.Rancher",
         "waitOn": {
           "reboot": "succeeded"
         }
@@ -25,7 +25,7 @@
         "label": "download-megaraid-firmware",
         "taskName": "Task.Linux.DownloadFiles",
         "waitOn": {
-          "bootstrap-ubuntu": "succeeded"
+          "bootstrap-rancher": "succeeded"
         }
       },
       {

--- a/quanta-d51-2u/workflows/write-quanta-bios-nvram-graph.json
+++ b/quanta-d51-2u/workflows/write-quanta-bios-nvram-graph.json
@@ -20,8 +20,8 @@
         }
       },
       {
-        "label": "bootstrap-ubuntu",
-        "taskName": "Task.Linux.Bootstrap.Ubuntu",
+        "label": "bootstrap-rancher",
+        "taskName": "Task.Linux.Bootstrap.Rancher",
         "waitOn": {
           "reboot": "succeeded"
         }
@@ -44,7 +44,7 @@
           "properties": {}
         },
         "waitOn": {
-          "bootstrap-ubuntu": "succeeded"
+          "bootstrap-rancher": "succeeded"
         }
       },
       {

--- a/quanta-t41/workflows/flash-quanta-bios-graph.json
+++ b/quanta-t41/workflows/flash-quanta-bios-graph.json
@@ -21,8 +21,8 @@
         }
       },
       {
-        "label": "bootstrap-ubuntu",
-        "taskName": "Task.Linux.Bootstrap.Ubuntu",
+        "label": "bootstrap-rancher",
+        "taskName": "Task.Linux.Bootstrap.Rancher",
         "waitOn": {
           "reboot": "succeeded"
         }
@@ -45,7 +45,7 @@
           "properties": {}
         },
         "waitOn": {
-          "bootstrap-ubuntu": "succeeded"
+          "bootstrap-rancher": "succeeded"
         }
       },
       {

--- a/quanta-t41/workflows/flash-quanta-bmc-graph.json
+++ b/quanta-t41/workflows/flash-quanta-bmc-graph.json
@@ -24,8 +24,8 @@
       },
       {
         "x-description": "Configure the node to load the microkernel image",
-        "label": "bootstrap-ubuntu",
-        "taskName": "Task.Linux.Bootstrap.Ubuntu",
+        "label": "bootstrap-rancher",
+        "taskName": "Task.Linux.Bootstrap.Rancher",
         "waitOn": {
           "reboot": "succeeded"
         }
@@ -34,7 +34,7 @@
         "label": "catalog-quanta-bmc-before",
         "taskName": "Task.Catalog.bmc",
         "waitOn": {
-          "bootstrap-ubuntu": "succeeded"
+          "bootstrap-rancher": "succeeded"
         }
       },
       {

--- a/quanta-t41/workflows/flash-quanta-megaraid-graph.json
+++ b/quanta-t41/workflows/flash-quanta-megaraid-graph.json
@@ -15,8 +15,8 @@
         }
       },
       {
-        "label": "bootstrap-ubuntu",
-        "taskName": "Task.Linux.Bootstrap.Ubuntu",
+        "label": "bootstrap-rancher",
+        "taskName": "Task.Linux.Bootstrap.Rancher",
         "waitOn": {
           "reboot": "succeeded"
         }
@@ -25,7 +25,7 @@
         "label": "download-megaraid-firmware",
         "taskName": "Task.Linux.DownloadFiles",
         "waitOn": {
-          "bootstrap-ubuntu": "succeeded"
+          "bootstrap-rancher": "succeeded"
         }
       },
       {

--- a/quanta-t41/workflows/write-quanta-bios-nvram-graph.json
+++ b/quanta-t41/workflows/write-quanta-bios-nvram-graph.json
@@ -20,8 +20,8 @@
         }
       },
       {
-        "label": "bootstrap-ubuntu",
-        "taskName": "Task.Linux.Bootstrap.Ubuntu",
+        "label": "bootstrap-rancher",
+        "taskName": "Task.Linux.Bootstrap.Rancher",
         "waitOn": {
           "reboot": "succeeded"
         }
@@ -44,7 +44,7 @@
           "properties": {}
         },
         "waitOn": {
-          "bootstrap-ubuntu": "succeeded"
+          "bootstrap-rancher": "succeeded"
         }
       },
       {


### PR DESCRIPTION
**Background**

Currently, we have replaced old microkernel with RancherOS, but we only use `bootstrap-rancher` to run discovery workflow. Here is to replace all other `bootstrap-ubuntu` with `bootstrap-rancher`. 
This is related with https://rackhd.atlassian.net/browse/RAC-6581

**Done**

* Replace all `bootstrap-ubuntu` with `bootstrap-rancher`
* Replace `overlayfsFile/overlayfsUri` with `dockerFile`

 
@RackHD/corecommitters @keedya 
  